### PR TITLE
Add file-based watch mode

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -100,6 +100,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 			extensions: ['.ts', '.tsx', '.js']
 		},
 		devtool: 'source-map',
+		watchOptions: { ignored: /node_modules/ },
 		plugins: [
 			new CssModulePlugin(basePath),
 			new AutoRequireWebpackPlugin(mainEntry),


### PR DESCRIPTION
Resolves #2. Introduces the `watch` build option that triggers a recompile after source file changes and works across all modes. I have confirmed that this works with the default app generated with [dojo/cli-create-app](https://github.com/dojo/cli-create-app).