### PR TITLE
Implement eject command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,15 @@ dojo build -s -w=memory # build to an in-memory file system with HMR
 
 ### Eject
 
-Ejecting `@dojo/cli-build-app` will produce a `config/build-app/ejected.config.js` file. After ejecting, the modes are specified using webpack's `env` flag (e.g., `--env.mode=dev`), defaulting to `dist`. Note that the dojorc can still be used in its existing format to specify build options. You can run a build using webpack with:
+Ejecting `@dojo/cli-build-app` will produce the following files under the `config/build-app` directory:
+
+- `ejected.config.js`: the root webpack config that reads the dojorc and passes it to the appropriate mode-specific config based on the `--env.mode` flag's value.
+- `base.config.js`: a common configuration used by the mode-specific configs.
+- `dev.config.js`: the configuration used during development.
+- `dist.config.js`: the production configuration.
+- `test.config.js`: the configuration used when running tests.
+
+As already noted, the dojorc can still be used even after ejecting, and the modes are specified using webpack's `env` flag (e.g., `--env.mode=dev`), defaulting to `dist`. You can run a build using webpack with:
 
 ```bash
 node_modules/.bin/webpack --config=config/build-app/ejected.config.js --env.mode={dev|dist|test}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ dojo build -s -w=memory # build to an in-memory file system with HMR
 
 ### Eject
 
-Eject is not currently supported by `cli-build-app`.
+Ejecting `@dojo/cli-build-app` will produce a `config/build-app/ejected.config.js` file. After ejecting, the modes are specified using webpack's `env` flag (e.g., `--env.mode=dev`), defaulting to `dist`. Note that the dojorc can still be used in its existing format to specify build options. You can run build using webpack with:
+
+```bash
+node_modules/.bin/webpack --config=config/build-app/ejected.config.js --env.mode={dev|dist|test}
+```
 
 ## How do I contribute?
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,14 @@ dojo build -s -w=memory # build to an in-memory file system with HMR
 
 Ejecting `@dojo/cli-build-app` will produce the following files under the `config/build-app` directory:
 
-- `ejected.config.js`: the root webpack config that reads the dojorc and passes it to the appropriate mode-specific config based on the `--env.mode` flag's value.
+- `build-options.json`: the build-specific config options removed from the `.dojorc`
+- `ejected.config.js`: the root webpack config that passes the build options to the appropriate mode-specific config based on the `--env.mode` flag's value.
 - `base.config.js`: a common configuration used by the mode-specific configs.
 - `dev.config.js`: the configuration used during development.
 - `dist.config.js`: the production configuration.
 - `test.config.js`: the configuration used when running tests.
 
-As already noted, the dojorc can still be used even after ejecting, and the modes are specified using webpack's `env` flag (e.g., `--env.mode=dev`), defaulting to `dist`. You can run a build using webpack with:
+As already noted, the dojorc's `build-app` options are moved to `config/build-app/build-options.json` after ejecting. Further, the modes are specified using webpack's `env` flag (e.g., `--env.mode=dev`), defaulting to `dist`. You can run a build using webpack with:
 
 ```bash
 node_modules/.bin/webpack --config=config/build-app/ejected.config.js --env.mode={dev|dist|test}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ dojo build -s -w=memory # build to an in-memory file system with HMR
 
 ### Eject
 
-Ejecting `@dojo/cli-build-app` will produce a `config/build-app/ejected.config.js` file. After ejecting, the modes are specified using webpack's `env` flag (e.g., `--env.mode=dev`), defaulting to `dist`. Note that the dojorc can still be used in its existing format to specify build options. You can run build using webpack with:
+Ejecting `@dojo/cli-build-app` will produce a `config/build-app/ejected.config.js` file. After ejecting, the modes are specified using webpack's `env` flag (e.g., `--env.mode=dev`), defaulting to `dist`. Note that the dojorc can still be used in its existing format to specify build options. You can run a build using webpack with:
 
 ```bash
 node_modules/.bin/webpack --config=config/build-app/ejected.config.js --env.mode={dev|dist|test}

--- a/src/ejected.config.ts
+++ b/src/ejected.config.ts
@@ -1,5 +1,3 @@
-import * as fs from 'fs';
-import * as path from 'path';
 import * as webpack from 'webpack';
 
 import devConfigFactory from './dev.config';
@@ -10,21 +8,9 @@ export interface EnvOptions {
 	mode?: 'dev' | 'dist' | 'test';
 }
 
-const basePath = process.cwd();
-
-function loadRc() {
-	const rcPath = path.join(basePath, '.dojorc');
-	const rcJson = fs.existsSync(rcPath) && fs.readFileSync(rcPath, 'utf-8');
-	let rc: any;
-	if (rcJson) {
-		rc = JSON.parse(rcJson)['build-app'];
-	}
-	return rc || {};
-}
-
 function webpackConfig(env: EnvOptions = {}): webpack.Configuration {
 	const { mode = 'dist' } = env;
-	const rc = loadRc();
+	const rc = require('./build-options.json');
 	let config: webpack.Configuration;
 	if (mode === 'dev') {
 		config = devConfigFactory(rc);

--- a/src/ejected.config.ts
+++ b/src/ejected.config.ts
@@ -2,9 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as webpack from 'webpack';
 
-const devConfigFactory = require('@dojo/cli-build-app/dev.config').default;
-const distConfigFactory = require('@dojo/cli-build-app/dist.config').default;
-const testConfigFactory = require('@dojo/cli-build-app/test.config').default;
+import devConfigFactory from './dev.config';
+import distConfigFactory from './dist.config';
+import testConfigFactory from './test.config';
 
 export interface EnvOptions {
 	mode?: 'dev' | 'dist' | 'test';

--- a/src/ejected.config.ts
+++ b/src/ejected.config.ts
@@ -1,0 +1,39 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as webpack from 'webpack';
+
+const devConfigFactory = require('@dojo/cli-build-app/dev.config').default;
+const distConfigFactory = require('@dojo/cli-build-app/dist.config').default;
+const testConfigFactory = require('@dojo/cli-build-app/test.config').default;
+
+export interface EnvOptions {
+	mode?: 'dev' | 'dist' | 'test';
+}
+
+const basePath = process.cwd();
+
+function loadRc() {
+	const rcPath = path.join(basePath, '.dojorc');
+	const rcJson = fs.existsSync(rcPath) && fs.readFileSync(rcPath, 'utf-8');
+	let rc: any;
+	if (rcJson) {
+		rc = JSON.parse(rcJson)['build-app'];
+	}
+	return rc || {};
+}
+
+function webpackConfig(env: EnvOptions = {}): webpack.Configuration {
+	const { mode = 'dist' } = env;
+	const rc = loadRc();
+	let config: webpack.Configuration;
+	if (mode === 'dev') {
+		config = devConfigFactory(rc);
+	} else if (mode === 'test') {
+		config = testConfigFactory(rc);
+	} else {
+		config = distConfigFactory(rc);
+	}
+	return config;
+}
+
+module.exports = webpackConfig;

--- a/src/main.ts
+++ b/src/main.ts
@@ -208,7 +208,7 @@ const command: Command = {
 		return {
 			copy: {
 				path: __dirname,
-				files: ['./ejected.config.js']
+				files: ['./base.config.js', './dev.config.js', './dist.config.js', './ejected.config.js', './test.config.js']
 			},
 			hints: [
 				`to build run ${chalk.underline(

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import devConfigFactory from './dev.config';
 import testConfigFactory from './test.config';
 import distConfigFactory from './dist.config';
 import logger from './logger';
+import { moveBuildOptions } from './util';
 
 const fixMultipleWatchTrigger = require('webpack-mild-compile');
 const hotMiddleware = require('webpack-hot-middleware');
@@ -204,11 +205,18 @@ const command: Command = {
 
 		return build(config);
 	},
-	eject(): EjectOutput {
+	eject(helper: Helper): EjectOutput {
 		return {
 			copy: {
 				path: __dirname,
-				files: ['./base.config.js', './dev.config.js', './dist.config.js', './ejected.config.js', './test.config.js']
+				files: [
+					moveBuildOptions(`${this.group}-${this.name}`),
+					'./base.config.js',
+					'./dev.config.js',
+					'./dist.config.js',
+					'./ejected.config.js',
+					'./test.config.js'
+				]
 			},
 			hints: [
 				`to build run ${chalk.underline(

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,40 @@
+import { Config } from '@dojo/interfaces/cli';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * @private
+ * Clear the rc data for the specified key (e.g., "build-app") from the dojorc and return
+ * the cleared data.
+ *
+ * @param key The rc key
+ * @return The cleared data
+ */
+function clearBuildOptions(key: string): Config {
+	const rcPath = path.join(process.cwd(), '.dojorc');
+	if (fs.existsSync(rcPath)) {
+		const rc = JSON.parse(fs.readFileSync(rcPath, 'utf8'));
+		const config = rc[key] || {};
+		rc[key] = {};
+		fs.writeFileSync(rcPath, JSON.stringify(rc));
+		return config;
+	}
+	return {};
+}
+
+/**
+ * Extract the rc data for the provided key to a temporary file and remove it from the dojorc.
+ * This utility is necessary given that "eject" is treated as a full command (see
+ * https://github.com/dojo/cli/issues/192 for more details).
+ *
+ * @param key The rc key (e.g., "build-app")
+ * @return The path to the temporary file
+ */
+export function moveBuildOptions(key: string): string {
+	const tmpDir = fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
+	const tmpRc = path.join(tmpDir, 'build-options.json');
+	const rc = clearBuildOptions(key);
+	fs.writeFileSync(tmpRc, JSON.stringify(rc));
+	return tmpRc;
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,2 +1,3 @@
+import './ejected.config';
 import './main';
 import './logger';

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,3 +1,4 @@
 import './ejected.config';
 import './main';
 import './logger';
+import './util';

--- a/tests/unit/ejected.config.ts
+++ b/tests/unit/ejected.config.ts
@@ -1,0 +1,80 @@
+const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import * as fs from 'fs';
+import { stub } from 'sinon';
+import MockModule from '../support/MockModule';
+
+let mockModule: MockModule;
+let mockDevConfig: any;
+let mockDistConfig: any;
+let mockTestConfig: any;
+let rc: any = { 'build-app': { bundles: {} } };
+
+describe('ejected config', () => {
+	beforeEach(() => {
+		mockModule = new MockModule('../../src/ejected.config', require);
+		mockModule.dependencies([
+			'@dojo/cli-build-app/dev.config',
+			'@dojo/cli-build-app/dist.config',
+			'@dojo/cli-build-app/test.config'
+		]);
+
+		stub(fs, 'existsSync').returns(true);
+		const readFileSync = fs.readFileSync;
+		stub(fs, 'readFileSync').callsFake((path: string, ...args: any[]) => {
+			if (path.indexOf('.dojorc') > -1) {
+				return JSON.stringify(rc);
+			}
+			return readFileSync(path, ...args);
+		});
+
+		const configs = ['dev', 'dist', 'test'].map(name => {
+			const config = mockModule.getMock(`@dojo/cli-build-app/${name}.config`);
+			config.default = stub();
+			return config.default;
+		});
+
+		mockDevConfig = configs[0];
+		mockDistConfig = configs[1];
+		mockTestConfig = configs[2];
+	});
+
+	afterEach(() => {
+		mockModule.destroy();
+		(fs as any).existsSync.restore();
+		(fs as any).readFileSync.restore();
+	});
+
+	it('can run dev mode', () => {
+		const config = mockModule.getModuleUnderTest();
+		config({ mode: 'dev' });
+		assert.isTrue(mockDevConfig.calledOnce);
+		assert.isTrue(mockDevConfig.calledWith(rc['build-app']));
+	});
+
+	it('can run dist mode', () => {
+		const config = mockModule.getModuleUnderTest();
+		config();
+		assert.isTrue(mockDistConfig.calledOnce);
+		assert.isTrue(mockDistConfig.calledWith(rc['build-app']));
+	});
+
+	it('can run test mode', () => {
+		const config = mockModule.getModuleUnderTest();
+		config({ mode: 'test' });
+		assert.isTrue(mockTestConfig.calledOnce);
+		assert.isTrue(mockTestConfig.calledWith(rc['build-app']));
+	});
+
+	it('can read build options from the dojorc', () => {
+		let config = mockModule.getModuleUnderTest();
+		config();
+		assert.isTrue(mockDistConfig.calledWith(rc['build-app']));
+
+		mockDistConfig.reset();
+		(fs as any).existsSync.returns(false);
+		config();
+
+		assert.isTrue(mockDistConfig.calledWith({}));
+	});
+});

--- a/tests/unit/ejected.config.ts
+++ b/tests/unit/ejected.config.ts
@@ -1,28 +1,18 @@
 const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
-import * as fs from 'fs';
 import { stub } from 'sinon';
 import MockModule from '../support/MockModule';
 
+const configJson: any = { bundles: {} };
 let mockModule: MockModule;
 let mockDevConfig: any;
 let mockDistConfig: any;
 let mockTestConfig: any;
-let rc: any = { 'build-app': { bundles: {} } };
 
 describe('ejected config', () => {
 	beforeEach(() => {
 		mockModule = new MockModule('../../src/ejected.config', require);
-		mockModule.dependencies(['./dev.config', './dist.config', './test.config']);
-
-		stub(fs, 'existsSync').returns(true);
-		const readFileSync = fs.readFileSync;
-		stub(fs, 'readFileSync').callsFake((path: string, ...args: any[]) => {
-			if (path.indexOf('.dojorc') > -1) {
-				return JSON.stringify(rc);
-			}
-			return readFileSync(path, ...args);
-		});
+		mockModule.dependencies(['./dev.config', './dist.config', './test.config', './build-options.json']);
 
 		const configs = ['dev', 'dist', 'test'].map(name => {
 			const config = mockModule.getMock(`./${name}.config`);
@@ -30,6 +20,7 @@ describe('ejected config', () => {
 			return config.default;
 		});
 
+		Object.assign(mockModule.getMock('./build-options.json'), configJson);
 		mockDevConfig = configs[0];
 		mockDistConfig = configs[1];
 		mockTestConfig = configs[2];
@@ -37,40 +28,26 @@ describe('ejected config', () => {
 
 	afterEach(() => {
 		mockModule.destroy();
-		(fs as any).existsSync.restore();
-		(fs as any).readFileSync.restore();
 	});
 
 	it('can run dev mode', () => {
 		const config = mockModule.getModuleUnderTest();
 		config({ mode: 'dev' });
 		assert.isTrue(mockDevConfig.calledOnce);
-		assert.isTrue(mockDevConfig.calledWith(rc['build-app']));
+		assert.isTrue(mockDevConfig.calledWith(configJson));
 	});
 
 	it('can run dist mode', () => {
 		const config = mockModule.getModuleUnderTest();
 		config();
 		assert.isTrue(mockDistConfig.calledOnce);
-		assert.isTrue(mockDistConfig.calledWith(rc['build-app']));
+		assert.isTrue(mockDistConfig.calledWith(configJson));
 	});
 
 	it('can run test mode', () => {
 		const config = mockModule.getModuleUnderTest();
 		config({ mode: 'test' });
 		assert.isTrue(mockTestConfig.calledOnce);
-		assert.isTrue(mockTestConfig.calledWith(rc['build-app']));
-	});
-
-	it('can read build options from the dojorc', () => {
-		let config = mockModule.getModuleUnderTest();
-		config();
-		assert.isTrue(mockDistConfig.calledWith(rc['build-app']));
-
-		mockDistConfig.reset();
-		(fs as any).existsSync.returns(false);
-		config();
-
-		assert.isTrue(mockDistConfig.calledWith({}));
+		assert.isTrue(mockTestConfig.calledWith(configJson));
 	});
 });

--- a/tests/unit/ejected.config.ts
+++ b/tests/unit/ejected.config.ts
@@ -13,11 +13,7 @@ let rc: any = { 'build-app': { bundles: {} } };
 describe('ejected config', () => {
 	beforeEach(() => {
 		mockModule = new MockModule('../../src/ejected.config', require);
-		mockModule.dependencies([
-			'@dojo/cli-build-app/dev.config',
-			'@dojo/cli-build-app/dist.config',
-			'@dojo/cli-build-app/test.config'
-		]);
+		mockModule.dependencies(['./dev.config', './dist.config', './test.config']);
 
 		stub(fs, 'existsSync').returns(true);
 		const readFileSync = fs.readFileSync;
@@ -29,7 +25,7 @@ describe('ejected config', () => {
 		});
 
 		const configs = ['dev', 'dist', 'test'].map(name => {
-			const config = mockModule.getMock(`@dojo/cli-build-app/${name}.config`);
+			const config = mockModule.getMock(`./${name}.config`);
 			config.default = stub();
 			return config.default;
 		});

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -393,7 +393,7 @@ describe('command', () => {
 			assert.deepEqual(ejectOptions, {
 				copy: {
 					path: join(basePath, '_build/src'),
-					files: ['./ejected.config.js']
+					files: ['./base.config.js', './dev.config.js', './dist.config.js', './ejected.config.js', './test.config.js']
 				},
 				hints: [
 					`to build run ${chalk.underline(

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -389,7 +389,11 @@ describe('command', () => {
 			const main = mockModule.getModuleUnderTest().default;
 			const packageJson = require(join(basePath, 'package.json'));
 			const ejectOptions = main.eject(getMockConfiguration());
+			const rcPattern = /build-options\.json$/;
 
+			assert.lengthOf(ejectOptions.copy.files.filter((file: string) => rcPattern.test(file)), 1);
+
+			ejectOptions.copy.files = ejectOptions.copy.files.filter((file: string) => !rcPattern.test(file));
 			assert.deepEqual(ejectOptions, {
 				copy: {
 					path: join(basePath, '_build/src'),

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -1,6 +1,8 @@
 const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
+import { join } from 'path';
 import { SinonStub, stub } from 'sinon';
+import chalk from 'chalk';
 import MockModule from '../support/MockModule';
 
 let mockModule: MockModule;
@@ -372,6 +374,52 @@ describe('command', () => {
 						mockLogger.calledWith('stats', { entry, output, plugins, watchOptions }, 'Listening on port 3000...')
 					);
 				});
+		});
+	});
+
+	describe('eject', () => {
+		const basePath = process.cwd();
+
+		beforeEach(() => {
+			mockModule.dependencies(['pkg-dir']);
+			mockModule.getMock('pkg-dir').ctor.sync = stub().returns(basePath);
+		});
+
+		it('outputs the ejected config and updates package dev dependencies', () => {
+			const main = mockModule.getModuleUnderTest().default;
+			const packageJson = require(join(basePath, 'package.json'));
+			const ejectOptions = main.eject(getMockConfiguration());
+
+			assert.deepEqual(ejectOptions, {
+				copy: {
+					path: join(basePath, '_build/src'),
+					files: ['./ejected.config.js']
+				},
+				hints: [
+					`to build run ${chalk.underline(
+						'./node_modules/.bin/webpack --config ./config/build-app/ejected.config.js --env.mode={dev|dist|test}'
+					)}`
+				],
+				npm: {
+					devDependencies: {
+						[packageJson.name]: packageJson.version,
+						...packageJson.dependencies
+					}
+				}
+			});
+		});
+
+		it('throws an error when ejecting when deps cannot be read', () => {
+			const message = 'Keyboard not found. Press F1 to resume.';
+			mockModule.getMock('pkg-dir').ctor.sync.throws(() => new Error(message));
+			assert.throws(
+				() => {
+					const main = mockModule.getModuleUnderTest().default;
+					main.eject(getMockConfiguration());
+				},
+				Error,
+				`Failed reading dependencies from package.json - ${message}`
+			);
 		});
 	});
 });

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -1,0 +1,60 @@
+const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+import * as path from 'path';
+
+import MockModule from '../support/MockModule';
+
+const key = 'build-app';
+const rc = { [key]: { bundles: {} } };
+let mockModule: MockModule;
+
+describe('util', () => {
+	beforeEach(() => {
+		mockModule = new MockModule('../../src/util', require);
+		mockModule.dependencies(['fs']);
+		mockModule.getMock('fs').existsSync.returns(true);
+		mockModule.getMock('fs').mkdtempSync.returns('/tmp');
+		mockModule.getMock('fs').readFileSync.returns(JSON.stringify(rc));
+	});
+
+	afterEach(() => {
+		mockModule.destroy();
+	});
+
+	describe('moveBuildOptions', () => {
+		it('should move the build options to a new file', () => {
+			const fs = mockModule.getMock('fs');
+			const { moveBuildOptions } = mockModule.getModuleUnderTest();
+			const buildOptions = JSON.stringify(rc[key]);
+
+			moveBuildOptions(key);
+
+			assert.isTrue(fs.writeFileSync.calledWith(path.join('/tmp', 'build-options.json'), buildOptions));
+			assert.isTrue(fs.writeFileSync.calledWith(path.join(process.cwd(), '.dojorc'), JSON.stringify({ [key]: {} })));
+		});
+
+		it('should default to an empty object when the key is missing from the rc', () => {
+			const fs = mockModule.getMock('fs');
+			const { moveBuildOptions } = mockModule.getModuleUnderTest();
+			const buildOptions = JSON.stringify({});
+
+			fs.readFileSync.returns(buildOptions);
+			moveBuildOptions(key);
+
+			assert.isTrue(fs.writeFileSync.calledWith(path.join('/tmp', 'build-options.json'), buildOptions));
+			assert.isTrue(fs.writeFileSync.calledWith(path.join(process.cwd(), '.dojorc')));
+		});
+
+		it('should always write a config even without a dojorc', () => {
+			const fs = mockModule.getMock('fs');
+			const { moveBuildOptions } = mockModule.getModuleUnderTest();
+			const buildOptions = JSON.stringify({});
+
+			fs.existsSync.returns(false);
+			moveBuildOptions(key);
+
+			assert.isTrue(fs.writeFileSync.calledWith(path.join('/tmp', 'build-options.json'), buildOptions));
+			assert.isFalse(fs.writeFileSync.calledWith(path.join(process.cwd(), '.dojorc')));
+		});
+	});
+});


### PR DESCRIPTION
Resolves #10. Configures the `eject` command to output a webpack config to the `config/build-app` directory that uses the `--env.mode` flag to specify the build mode.

I've verified this locally against a test application created with `dojo create app`. Some of this is copied from `cli-build-webpack`.