### PR TITLE
Reject command for build errors to ensure non zero exit code

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,7 +12,7 @@ const columns = require('cli-columns');
 const stripAnsi = require('strip-ansi');
 const version = jsonFile.readFileSync(path.join(pkgDir.sync(), 'package.json')).version;
 
-export default function logger(stats: any, config: any, runningMessage: string = '') {
+export default function logger(stats: any, config: any, runningMessage: string = ''): boolean {
 	const assets = stats.assets
 		.map((asset: any) => {
 			const size = (asset.size / 1000).toFixed(2);
@@ -72,4 +72,5 @@ ${chalk.yellow(`output at: ${chalk.cyan(chalk.underline(`file:///${config.output
 
 ${signOff}
 	`);
+	return !!errors;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,11 @@ function build(config: webpack.Configuration, args: any) {
 			}
 			if (stats) {
 				const runningMessage = args.serve ? `Listening on port ${args.port}...` : '';
-				logger(stats.toJson(), config, runningMessage);
+				const hasErrors = logger(stats.toJson(), config, runningMessage);
+				if (hasErrors) {
+					reject({});
+					return;
+				}
 			}
 			resolve(process.exit(0));
 		});

--- a/tests/unit/logger.ts
+++ b/tests/unit/logger.ts
@@ -15,7 +15,7 @@ let mockModule: MockModule;
 function assertOutput(isServing = false) {
 	const logger = mockModule.getModuleUnderTest().default;
 	const runningMessage = isServing ? 'running...' : undefined;
-	logger(
+	const hasErrors = logger(
 		{
 			hash: 'hash',
 			assets: [
@@ -71,6 +71,7 @@ ${signOff}
 	`;
 	const mockedLogUpdate = mockModule.getMock('log-update').ctor;
 	assert.isTrue(mockedLogUpdate.calledWith(expectedLog));
+	assert.isFalse(hasErrors);
 }
 
 describe('logger', () => {
@@ -103,7 +104,7 @@ describe('logger', () => {
 		const errors: any = ['error'];
 		const warnings: any = ['warning'];
 		const logger = mockModule.getModuleUnderTest().default;
-		logger(
+		const hasErrors = logger(
 			{
 				hash: 'hash',
 				assets: [
@@ -161,5 +162,6 @@ ${chalk.red('The build completed with errors.')}
 	`;
 		const mockedLogUpdate = mockModule.getMock('log-update').ctor;
 		assert.isTrue(mockedLogUpdate.calledWith(expectedLog));
+		assert.isTrue(hasErrors);
 	});
 });

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -310,6 +310,22 @@ describe('command', () => {
 			);
 		});
 
+		it('fails for build errors', () => {
+			const main = mockModule.getModuleUnderTest().default;
+			mockLogger.returns(true);
+			listenStub.callsFake((port: string, callback: Function) => {
+				callback(null, 'stats');
+			});
+			return main.run(getMockConfiguration(), {}).then(
+				() => {
+					throw new Error();
+				},
+				(e: Error) => {
+					assert.deepEqual(e, {});
+				}
+			);
+		});
+
 		it('limits --watch=memory to --mode=dev', () => {
 			const main = mockModule.getModuleUnderTest().default;
 			stub(console, 'warn');


### PR DESCRIPTION
**Type:** bug

**Description:**

The `@dojo/cli` automatically handles rejections with a non-zero exit code. However build errors were not considered or returned as a failure, only reported out to the console.

This changes logs whether an error has been detected and rejects the promise for the command.run so that the CLI can correctly exit.

resolves #80 