### PR TITLE
Dont end the process if we're serving

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ function build(config: webpack.Configuration, args: any) {
 				const runningMessage = args.serve ? `Listening on port ${args.port}...` : '';
 				logger(stats.toJson(), config, runningMessage);
 			}
-			resolve(process.exit(0));
+			resolve(args.serve || process.exit(0));
 		});
 	});
 }

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -284,6 +284,14 @@ describe('command', () => {
 			});
 		});
 
+		it('should not terminate the process when serving', () => {
+			const main = mockModule.getModuleUnderTest().default;
+			const port = 3000;
+			return main.run(getMockConfiguration(), { serve: true, port }).then(() => {
+				assert.isFalse(exitStub.called);
+			});
+		});
+
 		it('serves from the output directory', () => {
 			const main = mockModule.getModuleUnderTest().default;
 			const express = mockModule.getMock('express').ctor;


### PR DESCRIPTION
Fixes #82 

So I checked with Rory,  the description wasn't quite right. It does work for `dojo build -w -s`, but not for `dojo build -s`. The reason seems to be that when `dojo build -s` is run without -w, it runs the `build` function, which calls `process.exit(0)`. As it turns out the server stops running when the process ends.