### PR TITLE
`ignoreOrder` in `extract-text-webpack-plugin`

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -188,7 +188,8 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 			new IgnorePlugin(/request\/providers\/node/),
 			new ExtractTextPlugin({
 				filename: 'main.css',
-				allChunks: true
+				allChunks: true,
+				ignoreOrder: true
 			}),
 			new webpack.NamedChunksPlugin(),
 			new webpack.NamedModulesPlugin(),


### PR DESCRIPTION
Enabled the `ignoreOrder` option for `extract-text-webpack-plugin` –
solves https://github.com/dojo/cli-build-app/issues/86