### PR TITLE
allow .pcss as a extension for postcss files

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -223,7 +223,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 				},
 				{
 					include: allPaths,
-					test: /\.m\.css$/,
+					test: /\.m\.(p)?css$/,
 					enforce: 'pre',
 					loader: '@dojo/webpack-contrib/css-module-dts-loader?type=css'
 				},
@@ -268,20 +268,20 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 					use: ExtractTextPlugin.extract({ fallback: ['style-loader'], use: ['css-loader?sourceMap'] })
 				},
 				{
-					test: (path: string) => /\.m\.css$/.test(path) && !existsSync(path + '.js'),
+					test: (path: string) => /\.m\.(p)?css$/.test(path) && !existsSync(path + '.js'),
 					exclude: allPaths,
 					use: postCssModuleLoader
 				},
 				{ test: /\.m\.css\.js$/, exclude: allPaths, use: ['json-css-module-loader'] },
 				{
 					include: allPaths,
-					test: /\.css$/,
+					test: /\.(p)?css$/,
 					exclude: /\.m\.css$/,
 					use: cssLoader
 				},
 				{
 					include: allPaths,
-					test: /\.m\.css$/,
+					test: /\.m\.(p)?css$/,
 					use: postCssModuleLoader
 				}
 			])


### PR DESCRIPTION
This would allow css files to not only end in `.m.css` and `.css` but also `.m.pcss` and `.pcss` in order to interpret postcss files as such within the IDE.

I hope these changes are 100% correct, for some reason there are a total of 7 definitions for .css files in here - is this intended?

As this shouldn't break existing code I guess this could be merged quite quickly.