### PR TITLE
Support evergreen browsers

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -6,9 +6,5 @@
   "screenshotsFolder": "output/tests/screenshots",
   "videosFolder": "output/tests/videos",
   "supportFile": false,
-  "pluginsFile": false,
-  "reporter": "junit",
-  "reporterOptions": {
-	  "mochaFile": "./output/report/junit.xml"
-  }
+  "pluginsFile": false
 }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "2.6.1"
   },
   "dependencies": {
-    "@dojo/webpack-contrib": "2.0.0",
+    "@dojo/webpack-contrib": "2.0.1",
     "@theintern/istanbul-loader": "1.0.0-beta.1",
     "auto-require-webpack-plugin": "1.0.1",
     "chalk": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:ci": "run-p --race serve test",
     "serve": "http-server -p 9999 -c-1 --silent",
     "test": "npm run artefact:package && npm run artefact:install && grunt dev && grunt intern:node --test-reporter --color && npm run artefact:build && cypress run",
-    "artefact:build": "cd test-app && npm run build:dist && npm run build:dev",
+    "artefact:build": "cd test-app && npm run build:dist:evergreen && shx mv output/dist output/dist-evergreen  && npm run build:dev:evergreen && shx mv output/dev output/dev-evergreen && npm run build:dist && npm run build:dev && npm run build:dist:evergreen",
     "artefact:install": "cd test-app && shx rm -rf node_modules && npm i && npm run install-build-app",
     "artefact:package": "grunt dist && grunt release-publish-flat --dry-run && shx mv dist/dojo-cli-build-app-* dist/dojo-cli-build-app.tgz",
     "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -8,6 +8,7 @@ import * as ExtractTextPlugin from 'extract-text-webpack-plugin';
 import { WebAppManifest, WebpackConfiguration } from './interfaces';
 import * as loaderUtils from 'loader-utils';
 import * as ts from 'typescript';
+import getFeatures from '@dojo/webpack-contrib/static-build-loader/getFeatures';
 
 const IgnorePlugin = require('webpack/lib/IgnorePlugin');
 const AutoRequireWebpackPlugin = require('auto-require-webpack-plugin');
@@ -108,7 +109,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 	const manifest: WebAppManifest = args.pwa && args.pwa.manifest;
 	const extensions = args.legacy ? ['.ts', '.tsx', '.js'] : ['.ts', '.tsx', '.mjs', '.js'];
 	const compilerOptions = args.legacy ? {} : { target: 'es6', module: 'esnext' };
-	const features = args.legacy ? args.features : ['chrome'];
+	const features = args.legacy ? { ...(args.features || {}), ...getFeatures('chrome') } : args.features;
 	const lazyModules = Object.keys(args.bundles || {}).reduce(
 		(lazy, key) => {
 			lazy.push(...args.bundles[key]);

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -100,7 +100,7 @@ function importTransformer(basePath: string, bundles: any = {}) {
 					resolvedFileName
 						.replace(basePath, '')
 						.replace('.ts', '')
-						.replace(/^\//, '')
+						.replace(/^(\/|\\)/, '')
 				);
 				Object.keys(bundles).some(function(name) {
 					if (bundles[name].indexOf(slash(chunkName)) !== -1) {

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -139,9 +139,10 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 
 	if (lazyModules.length > 0) {
 		customTransformers.push(registryTransformer(basePath, lazyModules));
-		if (!args.legacy) {
-			customTransformers.push(importTransformer(basePath, args.bundles));
-		}
+	}
+
+	if (!args.legacy) {
+		customTransformers.push(importTransformer(basePath, args.bundles));
 	}
 
 	const tsLoaderOptions: any = {

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -109,7 +109,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 	const manifest: WebAppManifest = args.pwa && args.pwa.manifest;
 	const extensions = args.legacy ? ['.ts', '.tsx', '.js'] : ['.ts', '.tsx', '.mjs', '.js'];
 	const compilerOptions = args.legacy ? {} : { target: 'es6', module: 'esnext' };
-	const features = args.legacy ? { ...(args.features || {}), ...getFeatures('chrome') } : args.features;
+	const features = args.legacy ? args.features : { ...(args.features || {}), ...getFeatures('chrome') };
 	const lazyModules = Object.keys(args.bundles || {}).reduce(
 		(lazy, key) => {
 			lazy.push(...args.bundles[key]);

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -7,6 +7,7 @@ import I18nPlugin from '@dojo/webpack-contrib/i18n-plugin/I18nPlugin';
 import * as ExtractTextPlugin from 'extract-text-webpack-plugin';
 import { WebAppManifest, WebpackConfiguration } from './interfaces';
 import * as loaderUtils from 'loader-utils';
+import * as ts from 'typescript';
 
 const IgnorePlugin = require('webpack/lib/IgnorePlugin');
 const AutoRequireWebpackPlugin = require('auto-require-webpack-plugin');
@@ -83,8 +84,31 @@ Copyright [JS Foundation](https://js.foundation/) & contributors
 All rights reserved
 `;
 
+function importTransformer(basePath: string, lazyModules: string[]) {
+	return (context: any) => {
+		return (file: any) => ts.visitEachChild(file, visit, context);
+		function visit(node: any): any {
+			if (node.kind === ts.SyntaxKind.CallExpression) {
+				if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+					node.arguments[0] = ts.addSyntheticLeadingComment(
+						node.arguments[0],
+						ts.SyntaxKind.MultiLineCommentTrivia,
+						` webpackChunkName: "love-you" `,
+						false
+					);
+					return node;
+				}
+			}
+			return ts.visitEachChild(node, visit, context);
+		}
+	};
+}
+
 export default function webpackConfigFactory(args: any): WebpackConfiguration {
 	const manifest: WebAppManifest = args.pwa && args.pwa.manifest;
+	const extensions = args.legacy ? ['.ts', '.tsx', '.js'] : ['.ts', '.tsx', '.mjs', '.js'];
+	const compilerOptions = args.legacy ? {} : { target: 'es6', module: 'esnext' };
+	const features = args.legacy ? args.features : ['chrome'];
 	const lazyModules = Object.keys(args.bundles || {}).reduce(
 		(lazy, key) => {
 			lazy.push(...args.bundles[key]);
@@ -93,16 +117,23 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 		[] as string[]
 	);
 
-	const tsLoaderOptions: any = {
-		onlyCompileBundledFiles: true,
-		instance: 'dojo'
-	};
+	const customTransformers: any[] = [];
 
 	if (lazyModules.length > 0) {
-		tsLoaderOptions.getCustomTransformers = () => ({
-			before: [registryTransformer(basePath, lazyModules)]
-		});
+		customTransformers.push(registryTransformer(basePath, lazyModules));
+		if (!args.legacy) {
+			customTransformers.push(importTransformer(basePath, lazyModules));
+		}
 	}
+
+	const tsLoaderOptions: any = {
+		onlyCompileBundledFiles: true,
+		instance: 'dojo',
+		compilerOptions,
+		getCustomTransformers() {
+			return { before: customTransformers };
+		}
+	};
 
 	const postCssModuleLoader = ExtractTextPlugin.extract({
 		fallback: ['style-loader'],
@@ -177,7 +208,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 		},
 		resolve: {
 			modules: [basePath, path.join(basePath, 'node_modules')],
-			extensions: ['.ts', '.tsx', '.js']
+			extensions
 		},
 		devtool: 'source-map',
 		watchOptions: { ignored: /node_modules/ },
@@ -231,11 +262,11 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 					include: allPaths,
 					test: /\.ts(x)?$/,
 					use: removeEmpty([
-						args.features && {
+						features && {
 							loader: '@dojo/webpack-contrib/static-build-loader',
-							options: { features: args.features }
+							options: { features }
 						},
-						getUMDCompatLoader({ bundles: args.bundles }),
+						args.legacy && getUMDCompatLoader({ bundles: args.bundles }),
 						{
 							loader: 'ts-loader',
 							options: tsLoaderOptions
@@ -243,11 +274,20 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 					])
 				},
 				{
+					test: /\.mjs?$/,
+					use: removeEmpty([
+						features && {
+							loader: '@dojo/webpack-contrib/static-build-loader',
+							options: { features }
+						}
+					])
+				},
+				{
 					test: /\.js(x)?$/,
 					use: removeEmpty([
-						args.features && {
+						features && {
 							loader: '@dojo/webpack-contrib/static-build-loader',
-							options: { features: args.features }
+							options: { features }
 						},
 						'umd-compat-loader'
 					])

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,6 +188,13 @@ const command: Command = {
 			default: 9999,
 			type: 'number'
 		});
+
+		options('legacy', {
+			describe: 'build app with legacy browser support',
+			alias: 'l',
+			default: true,
+			type: 'boolean'
+		});
 	},
 	run(helper: Helper, args: any) {
 		console.log = () => {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -201,11 +201,11 @@ const command: Command = {
 		const rc = helper.configuration.get() || {};
 		let config: webpack.Configuration;
 		if (args.mode === 'dev') {
-			config = devConfigFactory(rc);
+			config = devConfigFactory({ ...rc, ...args });
 		} else if (args.mode === 'test') {
-			config = testConfigFactory(rc);
+			config = testConfigFactory({ ...rc, ...args });
 		} else {
-			config = distConfigFactory(rc);
+			config = distConfigFactory({ ...rc, ...args });
 		}
 
 		if (args.serve) {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -7,6 +7,8 @@
     "install-build-app": "npm install --no-save ../dist/dojo-cli-build-app.tgz",
     "build:dist": "dojo build --mode dist",
     "build:dev": "dojo build --mode dev",
+    "build:dist:evergreen": "dojo build --mode dist --legacy false",
+    "build:dev:evergreen": "dojo build --mode dev --legacy false",
     "build:test": "dojo build --mode test"
   },
   "author": "",

--- a/tests/integration/build.spec.ts
+++ b/tests/integration/build.spec.ts
@@ -9,10 +9,30 @@ Currently Rendered by BTR: false`
 		cy.get('#app-root').should('contain', 'Lazy Widget using dojorc configuration');
 		cy.get('script[src^="lazy"]').should('exist');
 		cy.get('script[src^="src/Foo"]').should('exist');
+
+		cy.visit('/test-app/output/dist-evergreen');
+		cy.get('#div').should(
+			'contain',
+			`Built with Build Time Render: true
+Currently Rendered by BTR: false`
+		);
+		cy.get('#app-root').should('contain', 'Lazy Widget using dojorc configuration');
+		cy.get('script[src^="lazy"]').should('exist');
+		cy.get('script[src^="src/Foo"]').should('exist');
 	});
 
 	it('dev', () => {
 		cy.visit('/test-app/output/dev');
+		cy.get('#div').should(
+			'contain',
+			`Built with Build Time Render: true
+Currently Rendered by BTR: false`
+		);
+		cy.get('#app-root').should('contain', 'Lazy Widget using dojorc configuration');
+		cy.get('script[src^="lazy"]').should('exist');
+		cy.get('script[src^="src/Foo"]').should('exist');
+
+		cy.visit('/test-app/output/dev-evergreen');
 		cy.get('#div').should(
 			'contain',
 			`Built with Build Time Render: true


### PR DESCRIPTION
Adds a new `legacy` flag that defaults to `true` to be backwards compatible. When set to false, uses our esm versions (`.mjs`) of our deps rather than the down emitted es5 umd (`.js`) modules.

Has to use a custom ts import transformer (which we should eventually move to `webpack-contrib`), to give us the same parity on bundling/codesplitting that we got before from a combination of the `promise-loader` and `umd-compat-loader`, neither which are used in evergreen.

Apart from the above the changes are mostly cribbed from the cli-build-widget changes here: https://github.com/dojo/cli-build-widget/pull/11