### PR TITLE
Always add an entry for the btr flag

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -213,7 +213,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 	const config: webpack.Configuration = {
 		entry: {
 			[mainEntry]: removeEmpty([
-				args['build-time-render'] && '@dojo/webpack-contrib/build-time-render/hasBuildTimeRender',
+				'@dojo/webpack-contrib/build-time-render/hasBuildTimeRender',
 				path.join(srcPath, 'main.css'),
 				mainEntryPath
 			])


### PR DESCRIPTION
The BTR has flag should be added regardless of whether build time rendering has been configured for the application. So that the btr has flag can be referenced without failing even when build time rendering is not turned on.