### PR TITLE
Evergreen builds by default

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -192,7 +192,7 @@ const command: Command = {
 		options('legacy', {
 			describe: 'build app with legacy browser support',
 			alias: 'l',
-			default: true,
+			default: false,
 			type: 'boolean'
 		});
 	},


### PR DESCRIPTION
Changes the default value for `legacy` to `false` by default for dojo 3.0.0