### PR TITLE
Configure source loader for mjs deps

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -260,13 +260,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 					options: { configuration: tsLint, emitErrors: true, failOnHint: true }
 				},
 				{
-					test: /@dojo\/.*\.mjs$/,
-					enforce: 'pre',
-					loader: 'source-map-loader-cli',
-					options: { includeModulePaths: true }
-				},
-				{
-					test: /@dojo\/.*\.js$/,
+					test: /@dojo\/.*\.(js|mjs)$/,
 					enforce: 'pre',
 					loader: 'source-map-loader-cli',
 					options: { includeModulePaths: true }

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -260,6 +260,12 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 					options: { configuration: tsLint, emitErrors: true, failOnHint: true }
 				},
 				{
+					test: /@dojo\/.*\.mjs$/,
+					enforce: 'pre',
+					loader: 'source-map-loader-cli',
+					options: { includeModulePaths: true }
+				},
+				{
 					test: /@dojo\/.*\.js$/,
 					enforce: 'pre',
 					loader: 'source-map-loader-cli',


### PR DESCRIPTION
**bug**

We were not loading source maps for `mjs` files, this was missed when the evergreen changes were included.