### PR TITLE
Use temporary terser package for uglify until we move to webpack 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "tslint": "5.8.0",
     "tslint-loader": "3.5.3",
     "typed-css-modules": "0.3.1",
-    "uglifyjs-webpack-plugin": "1.1.0",
+    "uglifyjs-webpack-plugin-terser": "1.1.0",
     "umd-compat-loader": "2.1.1",
     "webpack": "3.8.1",
     "webpack-bundle-analyzer-sunburst": "1.3.0",

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -15,7 +15,7 @@ import * as WebpackChunkHash from 'webpack-chunk-hash';
 
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer-sunburst').BundleAnalyzerPlugin;
 const WebpackPwaManifest = require('webpack-pwa-manifest');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin-terser');
 
 function webpackConfig(args: any): webpack.Configuration {
 	const config = baseConfigFactory(args);


### PR DESCRIPTION
Due to multiple issues with `uglify-es`, switch to the maintained fork `terser`. To use `terser` we either need to have the new webpack plugin for it or the newest version of `uglifyjs-webpack-plugin` (which supports custom minifiers), both require webpack 4 sadly. 

For now i've released a compat package that we can temporarily use until we move over to webpack 4