### PR TITLE
Add wrapper plugin that auto injects require() into entry for AMD loaders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1587,11 +1587,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
     },
-    "auto-require-webpack-plugin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/auto-require-webpack-plugin/-/auto-require-webpack-plugin-1.0.1.tgz",
-      "integrity": "sha1-A73jfHVuaMDdNtWtDxF5jWOMqSc="
-    },
     "autoprefixer": {
       "version": "6.7.7",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
@@ -2406,9 +2401,9 @@
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "ci-info": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.3.0.tgz",
-      "integrity": "sha512-mPdvoljUhH3Feai3dakD3bwYl/8I0tSo16Ge2W+tY88yfYDKGVnXV2vFxZC8VGME01CYp+DaAZnE93VHYVapnA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.3.1.tgz",
+      "integrity": "sha512-l4wK/SFEN8VVTQ9RO1I5yzIL2vw1w6My29qA6Gwaec80QeHxfXbruuUWqn1knyMoJn/X5kav3zVY1TlRHSKeIA==",
       "dev": true
     },
     "cipher-base": {
@@ -14915,6 +14910,14 @@
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
+      }
+    },
+    "wrapper-webpack-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wrapper-webpack-plugin/-/wrapper-webpack-plugin-1.0.0.tgz",
+      "integrity": "sha1-VcEWR/jKmQ/28EtB2PpK8JbDG7s=",
+      "requires": {
+        "webpack-sources": "^1.0.1"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
   "dependencies": {
     "@dojo/framework": "~3.0.0",
     "@dojo/webpack-contrib": "~3.0.1",
-    "auto-require-webpack-plugin": "1.0.1",
     "brotli-webpack-plugin": "0.5.0",
     "chalk": "2.4.1",
     "clean-webpack-plugin": "0.1.17",
@@ -144,6 +143,7 @@
     "webpack-hot-middleware": "2.21.0",
     "webpack-manifest-plugin": "1.3.2",
     "webpack-mild-compile": "1.0.0",
-    "webpack-pwa-manifest": "3.6.2"
+    "webpack-pwa-manifest": "3.6.2",
+    "wrapper-webpack-plugin": "1.0.0"
   }
 }


### PR DESCRIPTION
The `AutoRequireWebpackPlugin` no longer works with Webpack 3. Instead use the Wrapper plugin to do effectively the same thing.