### PR TITLE
Do not include allPaths for file-loader

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -337,7 +337,6 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 					loader: 'imports-loader?define=>false'
 				},
 				{
-					include: allPaths,
 					test: /\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2|ico)$/i,
 					loader: 'file-loader?hash=sha512&digest=hex&name=[name].[hash:base64:8].[ext]'
 				},


### PR DESCRIPTION
including `allPaths` for the `file-loader` causes the build to fail in certain scenarios:

```
errors:
./src/main.css
Module build failed: ModuleParseError: Module parse failed: Unexpected character '' (1:0)
You may need an appropriate loader to handle this file type.
(Source code omitted for this binary file)
```