### PR TITLE
Docs/legacy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ dojo build -s -w=memory -m=dev
 
 ### Legacy Browser Support
 
-By default, the build will support the last two versions of the latest browsers. To Support IE 11, run the build with the `--legacy` (`-l`) flag.
+By default, the build will support the last two versions of the latest browsers. To support IE 11 include any necessary polyfills, such as the fetch API, and run the build with the `--legacy` (`-l`) flag.
 
 ### Eject
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ dojo build -w
 dojo build -s -w=memory -m=dev
 ```
 
+### Legacy Browser Support
+
+By default, the build will support the last two versions of the latest browsers. To Support IE 11, run the build with the `--legacy` (`-l`) flag.
+
 ### Eject
 
 Ejecting `@dojo/cli-build-app` will produce the following files under the `config/build-app` directory:

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -162,7 +162,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 	};
 
 	const postcssPresetConfig = {
-		browsers: args.legacy ? ['last 2 versions', 'ie >= 11'] : ['last 2 versions'],
+		browsers: args.legacy ? ['last 2 versions', 'ie >= 10'] : ['last 2 versions'],
 		features: {
 			'nesting-rules': true
 		},

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -162,7 +162,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 	};
 
 	const postcssPresetConfig = {
-		browsers: args.legacy ? ['last 2 versions', 'ie >= 10'] : ['last 2 versions'],
+		browsers: args.legacy ? ['last 2 versions', 'ie >= 11'] : ['last 2 versions'],
 		features: {
 			'nesting-rules': true
 		},


### PR DESCRIPTION
Adds a a note to the readme about which browsers are supported and how to enable IE11 support. I'm not confident about the description so please make suggestions.

Resolves #157