### PR TITLE
Convert `color(` to `color-mod(` in css

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -128,6 +128,16 @@ function importTransformer(basePath: string, bundles: any = {}) {
 	};
 }
 
+interface CssStyle {
+	walkDecls(processor: (decl: { value: string }) => void): void;
+}
+
+function colorToColorMod(style: CssStyle) {
+	style.walkDecls((decl) => {
+		decl.value = decl.value.replace('color(', 'color-mod(');
+	});
+}
+
 export default function webpackConfigFactory(args: any): WebpackConfiguration {
 	const extensions = args.legacy ? ['.ts', '.tsx', '.js'] : ['.ts', '.tsx', '.mjs', '.js'];
 	const compilerOptions = args.legacy ? {} : { target: 'es6', module: 'esnext' };
@@ -163,7 +173,11 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 
 	const postcssPresetConfig = {
 		browsers: args.legacy ? ['last 2 versions', 'ie >= 10'] : ['last 2 versions'],
+		insertBefore: {
+			'color-mod-function': colorToColorMod
+		},
 		features: {
+			'color-mod-function': true,
 			'nesting-rules': true
 		},
 		autoprefixer: {

--- a/test-app/src/app.m.css
+++ b/test-app/src/app.m.css
@@ -5,4 +5,5 @@
 	width: 240px;
 	height: 100px;
 	color: var(--foreground-color);
+	background-color: color(black a(50%));
 }

--- a/tests/integration/build.spec.ts
+++ b/tests/integration/build.spec.ts
@@ -6,6 +6,7 @@ function testUrl(dir: string, isDist: boolean, isPwa: boolean) {
 Currently Rendered by BTR: false`
 	);
 	cy.get('#app-root').should('contain', 'Lazy Widget using dojorc configuration');
+	cy.get('#div').should('have.css', 'background-color', 'rgba(0, 0, 0, 0.5)');
 	cy.get('script[src^="lazy"]').should('exist');
 	cy.get('script[src^="src/Foo"]').should('exist');
 	cy.get('#div[nodeenv=production]').should(isDist ? 'exist' : 'not.exist');


### PR DESCRIPTION
Moving to `postcssPresetEnv ` meant that using the `color` function is no longer supported - the plugin that `postcssPresetEnv` leverages uses a function called `color-mod`.

This change provides a small plugin that runs before the `color-mod-function` plugin in `postcssPresetEnv` to convert uses of `color(` to `color-mod(`.

The new plugin is actually better, as it will use resolved variables when it executes, which will allow us to leave uncomputed css variables for non-legacy builds.