### PR TITLE
Pass dojo-debug feature as true for dev builds and false for dist builds

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -131,7 +131,8 @@ function importTransformer(basePath: string, bundles: any = {}) {
 export default function webpackConfigFactory(args: any): WebpackConfiguration {
 	const extensions = args.legacy ? ['.ts', '.tsx', '.js'] : ['.ts', '.tsx', '.mjs', '.js'];
 	const compilerOptions = args.legacy ? {} : { target: 'es6', module: 'esnext' };
-	const features = args.legacy ? args.features : { ...(args.features || {}), ...getFeatures('chrome') };
+	let features = args.legacy ? args.features : { ...(args.features || {}), ...getFeatures('chrome') };
+	features = { ...features, 'dojo-debug': false };
 	const assetsDir = path.join(process.cwd(), 'assets');
 	const assetsDirPattern = new RegExp(assetsDir);
 	const lazyModules = Object.keys(args.bundles || {}).reduce(

--- a/test-app/src/main.ts
+++ b/test-app/src/main.ts
@@ -29,6 +29,10 @@ if (process.env.NODE_ENV === 'production') {
 	div.setAttribute('nodeenv', 'production');
 }
 
+if (has('dojo-debug')) {
+	div.setAttribute('dojo-debug', 'true');
+}
+
 if (has('env') === 'prod') {
 	div.setAttribute('has-prod', 'prod');
 }

--- a/tests/integration/build.spec.ts
+++ b/tests/integration/build.spec.ts
@@ -10,6 +10,7 @@ Currently Rendered by BTR: false`
 	cy.get('script[src^="src/Foo"]').should('exist');
 	cy.get('#div[nodeenv=production]').should(isDist ? 'exist' : 'not.exist');
 	cy.get('#div[has-prod=prod]').should(isDist ? 'exist' : 'not.exist');
+	cy.get('#div[dojo-debug=true]').should(isDist ? 'not.exist' : 'exist');
 	cy.get('#div[has-ci=ci]').should(isDist ? 'not.exist' : 'exist');
 
 	cy.get('meta[name="mobile-web-app-capable"]').should(isPwa ? 'exist' : 'not.exist');


### PR DESCRIPTION
Implicitly add the `dojo-debug` has flag for `dev` and `dist` builds. The flag will be set to `true` for development builds and `false` for production builds.