### PR TITLE
fix: add new line before auto inject

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -333,7 +333,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 			new webpack.NamedModulesPlugin(),
 			new WrapperPlugin({
 				test: /(main.*(\.js$))/,
-				footer: `typeof define === 'function' && define.amd && require(['${libraryName}']);`
+				footer: `\ntypeof define === 'function' && define.amd && require(['${libraryName}']);`
 			}),
 			args.locale &&
 				new I18nPlugin({


### PR DESCRIPTION
Add a new line before auto injecting require() for AMD loaders. This fixes a syntax error with hot reloading of apps. The hot-update.js files do not have a semicolon at the end of them, so immediately appending typeof to that produces a syntax error.

Resolves #183 