### PR TITLE
Custom postcss-import loader for variables files

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -1,6 +1,6 @@
 import * as webpack from 'webpack';
 import * as path from 'path';
-import { existsSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import CssModulePlugin from '@dojo/webpack-contrib/css-module-plugin/CssModulePlugin';
 import ExternalLoaderPlugin from '@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin';
 import registryTransformer from '@dojo/webpack-contrib/registry-transformer';
@@ -197,6 +197,9 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 	const postcssImportConfig = {
 		filter: (path: string) => {
 			return /.*variables(\.m)?\.css$/.test(path);
+		},
+		load: (filename: string, importOptions: any = {}) => {
+			return readFileSync(filename, 'utf8').replace('color(', 'color-mod(');
 		},
 		resolve: (id: string, basedir: string, importOptions: any = {}) => {
 			if (importOptions.filter) {

--- a/test-app/src/app.m.css
+++ b/test-app/src/app.m.css
@@ -12,4 +12,5 @@
 
 .app {
 	border-color: var(--primary);
+	outline-color: color(var(--secondary) a(50%));
 }

--- a/test-app/src/variables.css
+++ b/test-app/src/variables.css
@@ -1,3 +1,4 @@
 :root {
 	--primary: red;
+	--secondary: color(var(--primary) a(15%));
 }

--- a/tests/integration/build.spec.ts
+++ b/tests/integration/build.spec.ts
@@ -8,6 +8,7 @@ Currently Rendered by BTR: false`
 		);
 		cy.get('#app-root').should('contain', 'Lazy Widget using dojorc configuration');
 		cy.get('#div').should('have.css', 'background-color', 'rgba(0, 0, 0, 0.5)');
+		cy.get('#vars').should('have.css', 'outline-color', 'rgba(255, 0, 0, 0.5)');
 		cy.get('script[src^="lazy"]').should('exist');
 		cy.get('script[src^="src/Foo"]').should('exist');
 		cy.get('script[src^="src/RoutedWidget"]').should('exist');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Custom loader for variables files to convert color function to color-mod as these go through the postcss-import plugin and do not get picked up by the custom plugin.

Resolves #188 
