### PR TITLE
Parse tsx bundle names correctly

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -110,7 +110,7 @@ function importTransformer(basePath: string, bundles: any = {}) {
 				let chunkName = slash(
 					resolvedFileName
 						.replace(basePath, '')
-						.replace('.ts', '')
+						.replace(/.ts(x)?$/, '')
 						.replace(/^(\/|\\)/, '')
 				);
 				Object.keys(bundles).some(function(name) {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Parse tsx bundle names propertly.
