### PR TITLE
Optimise generated CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7706,6 +7706,16 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "last-call-webpack-plugin": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-2.1.2.tgz",
+      "integrity": "sha512-CZc+m2xZm51J8qSwdODeiiNeqh8CYkKEq6Rw8IkE4i/4yqf2cJhjQPsA6BtAV970ePRNhwEOXhy2U5xc5Jwh9Q==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "webpack-sources": "^1.0.1"
+      }
+    },
     "latest-version": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
@@ -9593,6 +9603,16 @@
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
+      }
+    },
+    "optimize-css-assets-webpack-plugin": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha512-Fjn7wyyadPAriuH2DHamDQw5B8GohEWbroBkKoPeP+vSF2PIAPI7WDihi8WieMRb/At4q7Ea7zTKaMDuSoIAAg==",
+      "dev": true,
+      "requires": {
+        "cssnano": "^3.4.0",
+        "last-call-webpack-plugin": "^2.1.2"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "loader-utils": "1.1.0",
     "log-symbols": "2.1.0",
     "log-update": "2.3.0",
+    "optimize-css-assets-webpack-plugin": "3.2.0",
     "ora": "1.3.0",
     "pkg-dir": "2.0.0",
     "postcss-import": "12.0.0",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -328,7 +328,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 			new OptimizeCssAssetsPlugin({
 				cssProcessor: require('cssnano'),
 				cssProcessorPluginOptions: {
-					preset: ['default']
+					preset: ['default', { calc: false }]
 				}
 			}),
 			new webpack.NamedChunksPlugin(),

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -17,6 +17,7 @@ const postcssImport = require('postcss-import');
 const IgnorePlugin = require('webpack/lib/IgnorePlugin');
 const slash = require('slash');
 const WrapperPlugin = require('wrapper-webpack-plugin');
+const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
 const basePath = process.cwd();
 const srcPath = path.join(basePath, 'src');
@@ -323,6 +324,12 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 			new ExtractTextPlugin({
 				filename: 'main.css',
 				allChunks: true
+			}),
+			new OptimizeCssAssetsPlugin({
+				cssProcessor: require('cssnano'),
+				cssProcessorPluginOptions: {
+					preset: ['default']
+				}
 			}),
 			new webpack.NamedChunksPlugin(),
 			new webpack.NamedModulesPlugin(),

--- a/tests/integration/build.spec.ts
+++ b/tests/integration/build.spec.ts
@@ -43,19 +43,19 @@ Currently Rendered by BTR: false`
 		it('correctly inlines and resolves external variables for legacy builds', () => {
 			cy.request('/test-app/output/dev-app/main.css').then((response) => {
 				const css = response.body;
-				expect(css).to.contain('color: var(--foreground-color);');
-				expect(css).to.contain('color: blue;');
-				expect(css).to.contain('color: var(--primary);');
-				expect(css).to.contain('color: red;');
+				expect(css).to.contain('color:var(--foreground-color);');
+				expect(css).to.contain('color:blue;');
+				expect(css).to.contain('color:var(--primary);');
+				expect(css).to.contain('color:red;');
 			});
 		});
 		it('correctly inlines and resolves external variables for evergreen builds', () => {
 			cy.request('/test-app/output/dev-app-evergreen/main.css').then((response) => {
 				const css = response.body;
-				expect(css).to.contain('color: var(--foreground-color);');
-				expect(css).to.contain('color: blue;');
-				expect(css).to.contain('color: var(--primary);');
-				expect(css).to.contain('color: red;');
+				expect(css).to.contain('color:var(--foreground-color);');
+				expect(css).to.contain('color:blue;');
+				expect(css).to.contain('color:var(--primary);');
+				expect(css).to.contain('color:red;');
 			});
 		});
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Uses `optimize-css-assets-webpack-plugin` to optimise the built css, especially useful to remove duplicates created by inlining css variables.

Resolves #63 
