### PR TITLE
Fix patterns to check for windows paths too

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -26,7 +26,7 @@ const allPaths = [srcPath, testPath];
 const isTsx = existsSync(path.join(srcPath, 'main.tsx'));
 const mainEntryPath = path.join(srcPath, isTsx ? 'main.tsx' : 'main.ts');
 const mainCssPath = path.join(srcPath, 'main.css');
-const indexHtmlPattern = /src\/index\.html$/;
+const indexHtmlPattern = /src(\/|\\)index\.html$/;
 
 export const mainEntry = 'main';
 
@@ -279,7 +279,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 				function resolveExternal(externals: (string | { name?: string; type?: string })[]): string | void {
 					for (let external of externals) {
 						const name = external && (typeof external === 'string' ? external : external.name);
-						if (name && new RegExp(`^${name}[!\/]?`).test(request)) {
+						if (name && new RegExp(`^${name}[!(\/|\\)]?`).test(request)) {
 							return typeof external === 'string'
 								? request
 								: external.type
@@ -379,7 +379,7 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 					options: { configuration: tsLint, emitErrors: true, failOnHint: true }
 				},
 				{
-					test: /@dojo\/.*\.(js|mjs)$/,
+					test: /@dojo(\/|\\).*\.(js|mjs)$/,
 					enforce: 'pre',
 					loader: 'source-map-loader-cli',
 					options: { includeModulePaths: true }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Correct path tests to try both forward slash / (mac/linux) and backwaard slash \ (windows) to ensure proper compatibility.

Resolves #197 
