### PR TITLE
Small tweaks to base.config to speed up dev watch times

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -89,13 +89,6 @@ function getLocalIdent(
 
 const removeEmpty = (items: any[]) => items.filter((item) => item);
 
-const banner = `
-[Dojo](https://dojo.io/)
-Copyright [JS Foundation](https://js.foundation/) & contributors
-[New BSD license](https://github.com/dojo/meta/blob/master/LICENSE)
-All rights reserved
-`;
-
 function importTransformer(basePath: string, bundles: any = {}) {
 	return function(context: any) {
 		let resolvedModules: any;
@@ -170,8 +163,8 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 		},
 		[] as string[]
 	);
-	const singleBundle =
-		args.singleBundle || args.mode === 'unit' || args.mode === 'functional' || args.mode === 'test';
+	const isTest = args.mode === 'unit' || args.mode === 'functional' || args.mode === 'test';
+	const singleBundle = args.singleBundle || isTest;
 
 	const customTransformers: any[] = [];
 
@@ -326,7 +319,6 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 					maxChunks: 1
 				}),
 			new CssModulePlugin(basePath),
-			new webpack.BannerPlugin(banner),
 			new IgnorePlugin(/request\/providers\/node/),
 			new ExtractTextPlugin({
 				filename: 'main.css',
@@ -334,10 +326,11 @@ export default function webpackConfigFactory(args: any): WebpackConfiguration {
 			}),
 			new webpack.NamedChunksPlugin(),
 			new webpack.NamedModulesPlugin(),
-			new WrapperPlugin({
-				test: /(main.*(\.js$))/,
-				footer: `\ntypeof define === 'function' && define.amd && require(['${libraryName}']);`
-			}),
+			(args.externals || isTest) &&
+				new WrapperPlugin({
+					test: /(main.*(\.js$))/,
+					footer: `\ntypeof define === 'function' && define.amd && require(['${libraryName}']);`
+				}),
 			args.locale &&
 				new I18nPlugin({
 					defaultLocale: args.locale,

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -20,6 +20,13 @@ const CompressionPlugin = require('compression-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin-terser');
 const WebpackPwaManifest = require('webpack-pwa-manifest');
 
+const banner = `
+[Dojo](https://dojo.io/)
+Copyright [JS Foundation](https://js.foundation/) & contributors
+[New BSD license](https://github.com/dojo/meta/blob/master/LICENSE)
+All rights reserved
+`;
+
 function webpackConfig(args: any): webpack.Configuration {
 	const config = baseConfigFactory(args);
 	const manifest: WebAppManifest = args.pwa && args.pwa.manifest;
@@ -55,6 +62,7 @@ function webpackConfig(args: any): webpack.Configuration {
 					: manifest.icons
 			}),
 		new UglifyJsPlugin({ sourceMap: true, cache: true }),
+		new webpack.BannerPlugin(banner),
 		new WebpackChunkHash(),
 		new CleanWebpackPlugin(['dist'], { root: output.path, verbose: false }),
 		!args.singleBundle &&


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**
Both the banner and the wrapper plugin both have to write to the entire chunk and cost significant time during building. Move the banner plugin to `dist` only, given it's not important in `dev`. Only enable the wrapper plugin (which is for AMD support) if using externals or in one of the test modes. 

Sample build time with dev and watch:

before:
```
General output time took 4.78 secs
```
after:
```
General output time took 2.14 secs
```