### PR TITLE
Fix: do not rewrite sw file with history fallback

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -150,7 +150,7 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 					to: (context: any) => {
 						const { host, referer } = context.request.headers;
 						const { url: originalUrl } = context.request;
-						if (!referer || referer.endsWith(path.join(host, originalUrl))) {
+						if (!referer || referer.endsWith(host + originalUrl)) {
 							return originalUrl;
 						}
 						const parsedUrl = url.parse(referer);

--- a/src/main.ts
+++ b/src/main.ts
@@ -148,7 +148,12 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 				{
 					from: /^.*\.(?!html).*$/,
 					to: (context: any) => {
-						const parsedUrl = url.parse(context.request.headers.referer);
+						const { host, referer } = context.request.headers;
+						const { url: originalUrl } = context.request;
+						if (!referer || referer.endsWith(path.join(host, originalUrl))) {
+							return originalUrl;
+						}
+						const parsedUrl = url.parse(referer);
 						const pathnames = parsedUrl && parsedUrl.pathname ? parsedUrl.pathname.split('/') : [];
 						const urlRewrite = pathnames.reduce((rewrite, segment) => {
 							if (!segment) {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Update the history fallback rewriter to ignore both files without a referrer (direct access in the browser) and service worker files that are their own referrer.

Resolves #211 
