### PR TITLE
Remove memory watch and implement reload with normal watch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -409,9 +409,9 @@
       }
     },
     "@dojo/framework": {
-      "version": "5.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-5.0.0-alpha.3.tgz",
-      "integrity": "sha512-n6Cy3t7Zu65ceBM3UfqgBUmyM0F3JGUDIahMhXv4JKkXNaXSaUGuWDdBlRoH3LcEJDk6pj6ZV+J4JYiZ4IyPCQ==",
+      "version": "5.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-5.0.0-alpha.4.tgz",
+      "integrity": "sha512-nqF13sk3NtZNWrpRlhc51m+On50w9F0EEqVdSmO2TsFNSS4v40jhE+NYjgwp6V9pKg4GcA07H0mD78VkB1/sdg==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
@@ -590,7 +590,7 @@
       "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-5.0.0-alpha.7.tgz",
       "integrity": "sha512-MTMfKZcAnq05uO0VKuo/0OB4RzvcyI0pmR1C+s2Rky/Fc9SKcaKalQp8XgHJSCq1tNEpiEdB+nszhktpK5JlOw==",
       "requires": {
-        "@dojo/framework": "^5.0.0-alpha.3",
+        "@dojo/framework": "^5.0.0-alpha.4",
         "acorn": "5.3.0",
         "acorn-dynamic-import": "3.0.0",
         "bfj-node4": "5.2.0",
@@ -2501,9 +2501,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000918",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000918.tgz",
-      "integrity": "sha512-CAZ9QXGViBvhHnmIHhsTPSWFBujDaelKnUj7wwImbyQRxmXynYqKGi3UaZTSz9MoVh+1EVxOS/DFIkrJYgR3aw=="
+      "version": "1.0.30000921",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000921.tgz",
+      "integrity": "sha512-Bu09ciy0lMWLgpYC77I0YGuI8eFRBPPzaSOYJK1jTI64txCphYCqnWbxJYjHABYVt/TYX/p3jNjLBR87u1Bfpw=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -3048,6 +3048,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
       "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+    },
+    "connect-inject": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/connect-inject/-/connect-inject-0.4.0.tgz",
+      "integrity": "sha1-wunrHjd08sVqF8hY+WNnd62x4L4="
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -4600,9 +4605,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.90",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.90.tgz",
-      "integrity": "sha512-IjJZKRhFbWSOX1w0sdIXgp4CMRguu6UYcTckyFF/Gjtemsu/25eZ+RXwFlV+UWcIueHyQA1UnRJxocTpH5NdGA=="
+      "version": "1.3.91",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.91.tgz",
+      "integrity": "sha512-wOWwM4vQpmb97VNkExnwE5e/sUMUb7NXurlEnhE89JOarUp6FOOMKjtTGgj9bmqskZkeRA7u+p0IztJ/y2OP5Q=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -7188,7 +7193,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -7259,7 +7264,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -14931,9 +14936,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.12.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.14.tgz",
-          "integrity": "sha512-0rVcFRhM93kRGAU88ASCjX9Y3FWDCh+33G5Z5evpKOea4xcpLqDGwmo64+DjgaSezTN5j9KdnUzvxhOw7fNciQ=="
+          "version": "10.12.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+          "integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
         },
         "@types/webpack": {
           "version": "4.4.21",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "umd-compat-loader": "2.1.1",
     "webpack": "4.25.1",
     "webpack-chunk-hash": "0.6.0",
-    "webpack-dev-middleware": "3.4.0",
     "webpack-hot-middleware": "2.24.3",
     "webpack-manifest-plugin": "2.0.4",
     "webpack-mild-compile": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "cli-columns": "3.1.2",
     "compression-webpack-plugin": "2.0.0",
     "connect-history-api-fallback": "1.5.0",
+    "connect-inject": "0.4.0",
     "css-loader": "1.0.1",
     "eventsource-polyfill": "0.9.6",
     "express": "4.16.2",

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -82,7 +82,7 @@ function webpackConfig(args: any): webpack.Configuration {
 		}
 	}
 
-	if (args.watch !== 'memory' && args['build-time-render']) {
+	if (args['build-time-render']) {
 		config.plugins.push(
 			new BuildTimeRender({
 				...args['build-time-render'],

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -95,7 +95,7 @@ function webpackConfig(args: any): webpack.Configuration {
 		}
 	}
 
-	if (args.watch !== 'memory' && args['build-time-render']) {
+	if (args['build-time-render']) {
 		config.plugins.push(
 			new BuildTimeRender({
 				...args['build-time-render'],


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Removes "memory" watch which loaded bundles in memory and was not compatible with build time render. Changes the "file" watch to use the `webpack-hot-middleware` and support automatically reloading of the browser when used with `--serve`
