### PR TITLE
Remove hot module replacement plugin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,7 @@ function fileWatch(config: webpack.Configuration, args: any, app?: express.Appli
 		const entry = config.entry as any;
 		const plugins = config.plugins as webpack.Plugin[];
 		const timeout = 20 * 1000;
-		plugins.push(new webpack.HotModuleReplacementPlugin(), new webpack.NoEmitOnErrorsPlugin());
+		plugins.push(new webpack.NoEmitOnErrorsPlugin());
 		Object.keys(entry).forEach((name) => {
 			entry[name].unshift('eventsource-polyfill');
 		});

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -285,7 +285,6 @@ describe('command', () => {
 			mockDevConfig.returns({ entry, output, plugins, watchOptions });
 			mockDistConfig.returns({ entry, output, plugins, watchOptions });
 
-			webpack.HotModuleReplacementPlugin = stub();
 			webpack.NoEmitOnErrorsPlugin = stub();
 
 			useStub = stub();
@@ -485,8 +484,7 @@ describe('command', () => {
 					watch: true
 				})
 				.then(() => {
-					assert.lengthOf(plugins, 2);
-					assert.isTrue(webpack.HotModuleReplacementPlugin.calledWithNew());
+					assert.lengthOf(plugins, 1);
 					assert.isTrue(webpack.NoEmitOnErrorsPlugin.calledWithNew());
 					assert.sameMembers(entry.main, ['eventsource-polyfill']);
 				});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Stop using the `webpack.HotModuleReplacementPlugin` as [we have implemented a custom `client`](https://github.com/dojo/webpack-contrib/pull/111) that doesn't require the plugin when using `watch`
