### PR TITLE
Use manifest.json for logging

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,8 +17,8 @@ export default function logger(stats: any, config: any, runningMessage: string =
 	const assets = Object.keys(manifestContent).map((item) => {
 		const assetName = manifestContent[item];
 		const filePath = path.join(config.output.path, assetName);
-		const stats = fs.statSync(filePath);
-		const size = stats.size;
+		const fileStats = fs.statSync(filePath);
+		const size = (fileStats.size / 1000).toFixed(2);
 		const assetInfo = `${assetName} ${chalk.yellow(`(${size}kb)`)}`;
 		const content = fs.readFileSync(filePath, 'utf8');
 		const compressedSize = (gzipSize.sync(content) / 1000).toFixed(2);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,21 +13,17 @@ const stripAnsi = require('strip-ansi');
 const version = jsonFile.readFileSync(path.join(pkgDir.sync(__dirname), 'package.json')).version;
 
 export default function logger(stats: any, config: any, runningMessage: string = ''): boolean {
-	const assets = stats.assets
-		.map((asset: any) => {
-			const size = (asset.size / 1000).toFixed(2);
-			const assetInfo = `${asset.name} ${chalk.yellow(`(${size}kb)`)}`;
-			const contentFilePath = path.join(config.output.path, asset.name);
-
-			if (!fs.existsSync(contentFilePath)) {
-				return assetInfo;
-			}
-
-			const content = fs.readFileSync(contentFilePath, 'utf-8');
-			const compressedSize = (gzipSize.sync(content) / 1000).toFixed(2);
-			return `${assetInfo} / ${chalk.blue(`(${compressedSize}kb gz)`)}`;
-		})
-		.filter((output: string) => output);
+	const manifestContent = JSON.parse(fs.readFileSync(config.output.path, 'utf8'));
+	const assets = Object.keys(manifestContent).map((item) => {
+		const assetName = manifestContent[item];
+		const filePath = path.join(config.output.path, assetName);
+		const stats = fs.statSync(filePath);
+		const size = stats.size;
+		const assetInfo = `${assetName} ${chalk.yellow(`(${size}kb)`)}`;
+		const content = fs.readFileSync(filePath, 'utf8');
+		const compressedSize = (gzipSize.sync(content) / 1000).toFixed(2);
+		return `${assetInfo} / ${chalk.blue(`(${compressedSize}kb gz)`)}`;
+	});
 
 	const chunks = stats.chunks.map((chunk: any) => {
 		return `${chunk.names[0]}`;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,7 +13,7 @@ const stripAnsi = require('strip-ansi');
 const version = jsonFile.readFileSync(path.join(pkgDir.sync(__dirname), 'package.json')).version;
 
 export default function logger(stats: any, config: any, runningMessage: string = ''): boolean {
-	const manifestContent = JSON.parse(fs.readFileSync(config.output.path, 'utf8'));
+	const manifestContent = JSON.parse(fs.readFileSync(path.join(config.output.path, 'manifest.json'), 'utf8'));
 	const assets = Object.keys(manifestContent).map((item) => {
 		const assetName = manifestContent[item];
 		const filePath = path.join(config.output.path, assetName);

--- a/tests/fixtures/manifest.json
+++ b/tests/fixtures/manifest.json
@@ -1,0 +1,4 @@
+{
+	"assetOne.js": "assetOne.js",
+	"assetTwo.js": "assetOne.js"
+}

--- a/tests/unit/logger.ts
+++ b/tests/unit/logger.ts
@@ -44,11 +44,7 @@ function assertOutput(isServing = false) {
 		runningMessage
 	);
 
-	let assetOne = `assetOne.js ${chalk.yellow('(1.00kb)')}`;
-	if (!isServing) {
-		assetOne += ` / ${chalk.blue('(0.04kb gz)')}`;
-	}
-
+	let assetOne = `assetOne.js ${chalk.yellow('(0.03kb)')} / ${chalk.blue('(0.04kb gz)')}`;
 	let signOff = chalk.green('The build completed successfully.');
 	if (runningMessage) {
 		signOff += `\n\n${runningMessage}`;
@@ -70,6 +66,7 @@ ${chalk.yellow(`output at: ${chalk.cyan(chalk.underline(`file:///${path.join(__d
 ${signOff}
 	`;
 	const mockedLogUpdate = mockModule.getMock('log-update').ctor;
+	console.log(mockedLogUpdate.firstCall.args[0]);
 	assert.isTrue(mockedLogUpdate.calledWith(expectedLog));
 	assert.isFalse(hasErrors);
 }
@@ -153,8 +150,8 @@ ${chalk.yellow('chunks:')}
 ${columns(['chunkOne'])}
 ${chalk.yellow('assets:')}
 ${columns([
-			`assetOne.js ${chalk.yellow('(1.00kb)')} / ${chalk.blue('(0.04kb gz)')}`,
-			`assetOne.js ${chalk.yellow('(1.00kb)')} / ${chalk.blue('(0.04kb gz)')}`
+			`assetOne.js ${chalk.yellow('(0.03kb)')} / ${chalk.blue('(0.04kb gz)')}`,
+			`assetOne.js ${chalk.yellow('(0.03kb)')} / ${chalk.blue('(0.04kb gz)')}`
 		])}
 ${chalk.yellow(`output at: ${chalk.cyan(chalk.underline(`file:///${path.join(__dirname, '..', 'fixtures')}`))}`)}
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Favour the `manifest.json` over the webpack `stats` object for reporting asset information to the console.