### PR TITLE
Run clean on the info output directory on dist build

### DIFF
--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -73,7 +73,7 @@ function webpackConfig(args: any): webpack.Configuration {
 			}),
 		new webpack.BannerPlugin(banner),
 		new WebpackChunkHash(),
-		new CleanWebpackPlugin(['dist'], { root: output!.path, verbose: false })
+		new CleanWebpackPlugin(['dist', 'info'], { root: output!.path, verbose: false })
 	].filter((item) => item);
 
 	if (serviceWorker) {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Clean the `info` directory on `dist` builds
