### PR TITLE
Add `fetch` shim to the `BootstrapPlugin` options

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -401,6 +401,10 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 						{
 							module: '@dojo/framework/shim/WebAnimations',
 							has: 'web-animations'
+						},
+						{
+							module: '@dojo/framework/shim/fetch',
+							has: 'build-fetch'
 						}
 					]
 				}),


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds `@dojo/framework/shim/fetch` to the `BootstrapPlugin` configuration options.