### PR TITLE
Move externals plugin into configs

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -1,5 +1,4 @@
 import CssModulePlugin from '@dojo/webpack-contrib/css-module-plugin/CssModulePlugin';
-import ExternalLoaderPlugin from '@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin';
 import BootstrapPlugin from '@dojo/webpack-contrib/bootstrap-plugin/BootstrapPlugin';
 import I18nPlugin from '@dojo/webpack-contrib/i18n-plugin/I18nPlugin';
 import registryTransformer from '@dojo/webpack-contrib/registry-transformer';
@@ -363,13 +362,6 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					supportedLocales: args.supportedLocales,
 					cldrPaths: args.cldrPaths,
 					target: mainEntryPath
-				}),
-			args.externals &&
-				args.externals.dependencies &&
-				new ExternalLoaderPlugin({
-					dependencies: args.externals.dependencies,
-					hash: true,
-					outputPath: args.externals.outputPath
 				}),
 			!singleBundle &&
 				new webpack.DefinePlugin({

--- a/src/base.test.config.ts
+++ b/src/base.test.config.ts
@@ -1,5 +1,6 @@
 import * as webpack from 'webpack';
 import baseConfigFactory, { libraryName } from './base.config';
+import ExternalLoaderPlugin from '@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin';
 
 const WrapperPlugin = require('wrapper-webpack-plugin');
 
@@ -12,6 +13,13 @@ function webpackConfig(args: any): webpack.Configuration {
 
 	config.plugins = [
 		...plugins!,
+		args.externals &&
+			args.externals.dependencies &&
+			new ExternalLoaderPlugin({
+				dependencies: args.externals.dependencies,
+				hash: true,
+				outputPath: args.externals.outputPath
+			}),
 		new WrapperPlugin({
 			test: /(all.*(\.js$))/,
 			footer: `typeof define === 'function' && define.amd && define(['${libraryName}'], function() {});`

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import webpack = require('webpack');
 import BuildTimeRender from '@dojo/webpack-contrib/build-time-render/BuildTimeRender';
+import ExternalLoaderPlugin from '@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin';
 import ServiceWorkerPlugin, {
 	ServiceWorkerOptions
 } from '@dojo/webpack-contrib/service-worker-plugin/ServiceWorkerPlugin';
@@ -36,6 +37,13 @@ function webpackConfig(args: any): webpack.Configuration {
 			template: 'src/index.html',
 			cache: false
 		}),
+		args.externals &&
+			args.externals.dependencies &&
+			new ExternalLoaderPlugin({
+				dependencies: args.externals.dependencies,
+				hash: true,
+				outputPath: args.externals.outputPath
+			}),
 		manifest &&
 			new WebpackPwaManifest({
 				...manifest,

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -1,4 +1,5 @@
 import BuildTimeRender from '@dojo/webpack-contrib/build-time-render/BuildTimeRender';
+import ExternalLoaderPlugin from '@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin';
 import BundleAnalyzerPlugin from '@dojo/webpack-contrib/webpack-bundle-analyzer/BundleAnalyzerPlugin';
 import ServiceWorkerPlugin, {
 	ServiceWorkerOptions
@@ -63,6 +64,13 @@ function webpackConfig(args: any): webpack.Configuration {
 			template: 'src/index.html',
 			cache: false
 		}),
+		args.externals &&
+			args.externals.dependencies &&
+			new ExternalLoaderPlugin({
+				dependencies: args.externals.dependencies,
+				hash: true,
+				outputPath: args.externals.outputPath
+			}),
 		manifest &&
 			new WebpackPwaManifest({
 				...manifest,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Move the ExternalLoaderPlugin into the configs since it must be registered after the HtmlWebpackPlugin in order to function correctly.

Resolves dojo/webpack-contrib#119
