### PR TITLE
Try to serve static before rewrites when using serve option

### DIFF
--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -466,7 +466,7 @@ describe('command', () => {
 					watch: true
 				})
 				.then(() => {
-					assert.strictEqual(useStub.callCount, 4);
+					assert.strictEqual(useStub.callCount, 5);
 					assert.isTrue(
 						hotMiddleware.calledWith(compiler, {
 							heartbeat: 10000


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

When using BTR with `StateHistory` an `index.html` is written for each path configured, so when using `serve` option it shouldn't automatically rewrite index requests to the main `index.html`. This changes the middleware to try and serve files before re-writing the URL and only re-writes the URL when the index file does not exist.
