### PR TITLE
Use the entry name for externals based on single bundle config

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -353,7 +353,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 			}),
 			(args.externals || isTest) &&
 				new WrapperPlugin({
-					test: /(main.*(\.js$))/,
+					test: singleBundle ? new RegExp(`${mainEntry}.*(\.js$)`) : new RegExp(`${bootstrapEntry}.*(\.js$)`),
 					footer: `\ntypeof define === 'function' && define.amd && require(['${libraryName}']);`
 				}),
 			args.locale &&


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Switch the entry name for `externals` based on the type of build.