### PR TITLE
Add slash to paths that need them in serve

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -136,7 +136,7 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 	const app = express();
 	app.use(function(req, res, next) {
 		const { pathname } = url.parse(req.url);
-		if (pathname && !pathname.match(/\..*$/) && pathname !== '/__webpack_hmr') {
+		if (req.is('html') && pathname && !pathname.match(/\..*$/)) {
 			req.url = `${req.url}/`;
 		}
 		next();

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,13 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 	let isHttps = false;
 
 	const app = express();
+	app.use(function(req, res, next) {
+		const { pathname } = url.parse(req.url);
+		if (pathname && !pathname.match(/\..*$/) && pathname !== '/__webpack_hmr') {
+			req.url = `${req.url}/`;
+		}
+		next();
+	});
 	app.use(
 		connectInject({
 			rules: [

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -466,7 +466,7 @@ describe('command', () => {
 					watch: true
 				})
 				.then(() => {
-					assert.strictEqual(useStub.callCount, 5);
+					assert.strictEqual(useStub.callCount, 6);
 					assert.isTrue(
 						hotMiddleware.calledWith(compiler, {
 							heartbeat: 10000


### PR DESCRIPTION
**Type:** bug

**Description:**
In serve mode, if serve-static can't resolve a file it sends a 301 redirect with an additional slash. This causes problems with relative paths on the page afterwards.

Rather than having this behaviour, instead opt to add the slash before resolving in serve-static.
