### PR TITLE
Set target for functionals to node

### DIFF
--- a/src/functional.config.ts
+++ b/src/functional.config.ts
@@ -10,6 +10,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	const config = baseTestConfigFactory(args);
 	const { output, plugins } = config;
 	const outputPath = output!.path as string;
+	config.target = 'node';
 	config.entry = () => {
 		const functional = globby
 			.sync([`${basePath}/tests/functional/**/*.ts`])


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Build functionals for a node target as the bundle runs in node.
