### PR TITLE
V5 - set target for functionals to node (#248)

### DIFF
--- a/src/functional.config.ts
+++ b/src/functional.config.ts
@@ -10,6 +10,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	const config = baseTestConfigFactory(args);
 	const { output, plugins } = config;
 	const outputPath = output!.path as string;
+	config.target = 'node';
 	config.entry = () => {
 		const functional = globby
 			.sync([`${basePath}/tests/functional/**/*.ts`])


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Set build target to node for functionals