### PR TITLE
Deal with assets that do not exist in the output

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -21,12 +21,15 @@ export default function logger(stats: any, config: any, runningMessage: string =
 		assets = Object.keys(manifestContent).map((item) => {
 			const assetName = manifestContent[item];
 			const filePath = path.join(config.output.path, assetName);
-			const fileStats = fs.statSync(filePath);
-			const size = (fileStats.size / 1000).toFixed(2);
-			const assetInfo = `${assetName} ${chalk.yellow(`(${size}kb)`)}`;
-			const content = fs.readFileSync(filePath, 'utf8');
-			const compressedSize = (gzipSize.sync(content) / 1000).toFixed(2);
-			return `${assetInfo} / ${chalk.blue(`(${compressedSize}kb gz)`)}`;
+			if (fs.existsSync(filePath)) {
+				const fileStats = fs.statSync(filePath);
+				const size = (fileStats.size / 1000).toFixed(2);
+				const assetInfo = `${assetName} ${chalk.yellow(`(${size}kb)`)}`;
+				const content = fs.readFileSync(filePath, 'utf8');
+				const compressedSize = (gzipSize.sync(content) / 1000).toFixed(2);
+				return `${assetInfo} / ${chalk.blue(`(${compressedSize}kb gz)`)}`;
+			}
+			return '';
 		});
 
 		chunks = stats.chunks.map((chunk: any) => {

--- a/tests/fixtures/missing-assets/assetOne.js
+++ b/tests/fixtures/missing-assets/assetOne.js
@@ -1,0 +1,1 @@
+function myFunction() {}

--- a/tests/fixtures/missing-assets/manifest.json
+++ b/tests/fixtures/missing-assets/manifest.json
@@ -1,0 +1,4 @@
+{
+	"assetOne.js": "assetOne.js",
+	"assetTwo.js": "assetTwo.js"
+}

--- a/tests/unit/logger.ts
+++ b/tests/unit/logger.ts
@@ -166,4 +166,59 @@ ${chalk.red('The build completed with errors.')}
 		assert.isTrue(mockedLogUpdate.calledWith(expectedLog));
 		assert.isTrue(hasErrors);
 	});
+
+	it('should skip assets that do not exist', () => {
+		const logger = mockModule.getModuleUnderTest().default;
+		const hasErrors = logger(
+			{
+				hash: 'hash',
+				assets: [
+					{
+						name: 'assetOne.js',
+						size: 1000
+					},
+					{
+						name: 'assetTwo.js',
+						size: 1000
+					}
+				],
+				chunks: [
+					{
+						names: ['chunkOne']
+					}
+				],
+				errors: [],
+				warnings: []
+			},
+			{
+				output: {
+					path: path.join(__dirname, '..', 'fixtures', 'missing-assets')
+				}
+			}
+		);
+
+		const expectedLog = `
+${logSymbols.info} cli-build-app: 9.9.9
+${logSymbols.info} typescript: 1.1.1
+${logSymbols.success} hash: hash
+${logSymbols.error} errors: 0
+${logSymbols.warning} warnings: 0
+${''}${''}
+${chalk.yellow('chunks:')}
+${columns(['chunkOne'])}
+${chalk.yellow('assets:')}
+${columns([`assetOne.js ${chalk.yellow('(0.03kb)')} / ${chalk.blue('(0.04kb gz)')}`])}
+${chalk.yellow(
+			`output at: ${chalk.cyan(
+				chalk.underline(`file:///${path.join(__dirname, '..', 'fixtures', 'missing-assets')}`)
+			)}`
+		)}
+
+${chalk.green('The build completed successfully.')}
+	`;
+		const mockedLogUpdate = mockModule.getMock('log-update').ctor;
+		assert.strictEqual(mockedLogUpdate.firstCall.args[0], expectedLog);
+		assert.isTrue(mockedLogUpdate.calledWith(expectedLog));
+		assert.isFalse(hasErrors);
+	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Skip assets that do not exist the when logging the command output. This stops the build crashing when using `--watch` with BTR and Blocks.

Resolves #256 
