### PR TITLE
Ensure the snippet is injected inside the html body

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -149,7 +149,7 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 					snippet:
 						"<script>window.DojoHasEnvironment = { staticFeatures: { 'build-serve': true } };</script>",
 					fn: (match: string, snippet: string) => {
-						return snippet + match;
+						return match + snippet;
 					}
 				}
 			]


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Ensure that the script that sets the `build-serve` has flag is injected inside the html body.

Resolves #255 
