### PR TITLE
Ignoring css files for BannerPlugin

### DIFF
--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -79,7 +79,7 @@ function webpackConfig(args: any): webpack.Configuration {
 			}),
 		new webpack.BannerPlugin({
 			banner,
-			test: /^.*(?<!\.css)$/i
+			test: /^(.(?!.*\.css$))*$/i
 		}),
 		new WebpackChunkHash(),
 		new CleanWebpackPlugin(['dist', 'info'], { root: output!.path, verbose: false })

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -79,7 +79,7 @@ function webpackConfig(args: any): webpack.Configuration {
 			}),
 		new webpack.BannerPlugin({
 			banner,
-			test: /^(.(?!.*\.css$))*$/i
+			test: /^.*\.js$/i
 		}),
 		new WebpackChunkHash(),
 		new CleanWebpackPlugin(['dist', 'info'], { root: output!.path, verbose: false })

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -77,7 +77,10 @@ function webpackConfig(args: any): webpack.Configuration {
 					? manifest.icons.map((icon) => ({ ...icon, ios: true }))
 					: manifest.icons
 			}),
-		new webpack.BannerPlugin(banner),
+		new webpack.BannerPlugin({
+			banner,
+			test: /^.*(?<!\.css)$/i
+		}),
 		new WebpackChunkHash(),
 		new CleanWebpackPlugin(['dist', 'info'], { root: output!.path, verbose: false })
 	].filter((item) => item);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Running `BannerPlugin` on the css files is messing up the source maps. Just ignoring css files seems to resolve the issue.

Resolves #261
