### PR TITLE
Make extra watch files configurable

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -187,6 +187,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	const isTest = args.mode === 'unit' || args.mode === 'functional' || args.mode === 'test';
 	const singleBundle = args.singleBundle || isTest;
 	const watch = args.watch;
+	const watchExtraFiles = Array.isArray(args.watchExtraFiles) ? args.watchExtraFiles : [];
 	let entry: any;
 	if (singleBundle) {
 		entry = {
@@ -445,8 +446,9 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					]
 				}),
 			watch &&
+				watchExtraFiles.length &&
 				new ExtraWatchWebpackPlugin({
-					files: ['!(output|.*|node_modules)/**']
+					files: watchExtraFiles
 				}),
 			new ManifestPlugin()
 		]),


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR


**Description:**
Make the extra files for watching configurable via the `.dojorc`, as watching the entire root project directory can sometimes cause performance issues depending on project structure.