### PR TITLE
Backport: make extra watch files configurable (#264)

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -170,6 +170,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	const isTest = args.mode === 'unit' || args.mode === 'functional' || args.mode === 'test';
 	const singleBundle = args.singleBundle || isTest;
 	const watch = args.watch;
+	const watchExtraFiles = Array.isArray(args.watchExtraFiles) ? args.watchExtraFiles : [];
 	let entry: any;
 	if (singleBundle) {
 		entry = {
@@ -403,8 +404,9 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					]
 				}),
 			watch &&
+				watchExtraFiles.length &&
 				new ExtraWatchWebpackPlugin({
-					files: ['!(output|.*|node_modules)/**']
+					files: watchExtraFiles
 				}),
 			new ManifestPlugin()
 		]),


### PR DESCRIPTION
(cherry picked from commit 6b8fcca215aeb6f779503fd8e87ef4d6d5bd0d62)

**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**
Backport of #264 
