### PR TITLE
Backport: Add --omit-hash CLI argument to omit hashes from output filenames. (#…

### DIFF
--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -106,7 +106,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	config.plugins = config.plugins.map((plugin) => {
 		if (plugin instanceof MiniCssExtractPlugin) {
 			return new MiniCssExtractPlugin({
-				filename: '[name].[contenthash].bundle.css'
+				filename: args.omitHash ? '[name].bundle.css' : '[name].[contenthash].bundle.css'
 			});
 		}
 		return plugin;
@@ -127,8 +127,8 @@ function webpackConfig(args: any): webpack.Configuration {
 	config.output = {
 		...output,
 		path: outputPath,
-		chunkFilename: '[name].[chunkhash].bundle.js',
-		filename: '[name].[chunkhash].bundle.js'
+		chunkFilename: args.omitHash ? '[name].bundle.js' : '[name].[chunkhash].bundle.js',
+		filename: args.omitHash ? '[name].bundle.js' : '[name].[chunkhash].bundle.js'
 	};
 
 	return config;

--- a/src/main.ts
+++ b/src/main.ts
@@ -285,6 +285,13 @@ const command: Command = {
 			type: 'boolean'
 		});
 
+		options('omit-hash', {
+			describe: 'Omits hashes from output file names in dist mode',
+			defaultDescription: '(always false for dev builds)',
+			default: false,
+			type: 'boolean'
+		});
+
 		options('legacy', {
 			describe: 'build app with legacy browser support',
 			alias: 'l',


### PR DESCRIPTION
…268)

* Add --omit-hash CLI argument to omit hashes from the output filenames.

* Omit hashes from all bundles when using --omit-hash

(cherry picked from commit 3840e30f8aedc6c1b76280ef406b412000fa745c)
