### PR TITLE
Set flag included chunks to `false`

### DIFF
--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -42,7 +42,8 @@ function webpackConfig(args: any): webpack.Configuration {
 
 	config.optimization = {
 		...config.optimization,
-		minimizer: [new TerserPlugin({ sourceMap: true, cache: true })]
+		minimizer: [new TerserPlugin({ sourceMap: true, cache: true })],
+		flagIncludedChunks: false
 	};
 
 	config.plugins = [


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Set the `flagIncludedChunks` optimisation to `false` in `dist` mode to ensure that chunks are always loaded. This resolves issues with using blocks and code splitting.

Resolves #272 
