### PR TITLE
Exclude some superfluous node polyfills

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -335,7 +335,15 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 			}
 		],
 		entry,
-		node: { dgram: 'empty', net: 'empty', tls: 'empty', fs: 'empty' },
+		node: {
+			dgram: 'empty',
+			net: 'empty',
+			tls: 'empty',
+			fs: 'empty',
+			process: false,
+			Buffer: false,
+			setImmediate: false
+		},
 		output: {
 			chunkFilename: '[name].js',
 			library: libraryName,


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**
Reduces the bootstrap bundle from:
```
bootstrap.e6a3e052d31da18bd0b9.bundle.js (16.09kb) / (5.66kb gz)
```
to
```
bootstrap.d8fdd21580e892e3e42f.bundle.js (13.00kb) / (4.61kb gz)
```
