### PR TITLE
Explicitly add type dependency that got bumped and caused a type error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -622,23 +622,24 @@
       }
     },
     "@dojo/framework": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-5.0.4.tgz",
-      "integrity": "sha512-E8y+E6k6VgVOCiTQqokFEmxODuL4p6b7BroiGo5DNEgmS9dRMMHsO6UadDHx/TOsw47vP56Ly+ugHZbpS/XcWg==",
+      "version": "6.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.1.tgz",
+      "integrity": "sha512-/tPwqHqmYImAOymGOZ/d65tQt7zZJ9Vy8r6Uwdm6edplmmkygryIVuRjKj7SN+2VsLdexXlnwJ9y+/CZNzBCOA==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
         "@webcomponents/webcomponentsjs": "1.1.0",
         "cldrjs": "0.5.0",
+        "cross-fetch": "3.0.2",
         "css-select-umd": "1.3.0-rc0",
         "diff": "3.5.0",
         "globalize": "1.4.0",
+        "immutable": "3.8.2",
         "intersection-observer": "0.4.2",
         "pepjs": "0.4.2",
         "resize-observer-polyfill": "1.5.0",
         "tslib": "1.8.1",
-        "web-animations-js": "2.3.1",
-        "whatwg-fetch": "3.0.0"
+        "web-animations-js": "2.3.1"
       }
     },
     "@dojo/scripts": {
@@ -764,15 +765,16 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-5.0.3.tgz",
-      "integrity": "sha512-X2wI2TDNwGBmxk6C9wujZhwfF37mezBzZ0hliiVNACRuDtocyakpJri6cl1Ct8CnTEWxscIrVJPRGoKkNi00Rg==",
+      "version": "6.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-6.0.0-alpha.2.tgz",
+      "integrity": "sha512-3l6W1EMFnSTYQ41pucAqMWbiBJZk4VkcnXiGQoZdxPpY3DEi7Cb/sObOMpXzPSMs4ND/VqswuFh8U0it1bbnNw==",
       "requires": {
-        "@dojo/framework": "^5.0.0",
+        "@dojo/framework": "6.0.0-alpha.1",
         "acorn": "5.3.0",
         "acorn-dynamic-import": "3.0.0",
         "bfj": "6.1.1",
         "chalk": "2.3.0",
+        "clear-module": "3.1.0",
         "commander": "2.13.0",
         "connect-history-api-fallback": "1.6.0",
         "copy-webpack-plugin": "4.6.0",
@@ -788,6 +790,7 @@
         "istanbul-lib-instrument": "1.10.1",
         "loader-utils": "1.1.0",
         "lodash": "4.17.4",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "node-html-parser": "1.1.11",
         "opener": "1.4.3",
@@ -796,6 +799,7 @@
         "recast": "0.12.7",
         "source-map": "0.6.1",
         "ts-loader": "5.3.0",
+        "ts-node": "^8.0.3",
         "typed-css-modules": "0.3.7",
         "webpack-hot-middleware": "2.24.3",
         "workbox-webpack-plugin": "3.6.3",
@@ -821,6 +825,18 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
           "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
+        },
+        "ts-node": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.1.0.tgz",
+          "integrity": "sha512-34jpuOrxDuf+O6iW1JpgTRDFynUZ1iEqtYruBqh35gICNjN8x+LpVcPAcwzLPi9VU6mdA3ym+x233nZmZp445A==",
+          "requires": {
+            "arg": "^4.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^3.0.0"
+          }
         },
         "typed-css-modules": {
           "version": "0.3.7",
@@ -915,9 +931,9 @@
       }
     },
     "@theintern/digdug": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.2.3.tgz",
-      "integrity": "sha512-K3udP/hLAI/0snTBo92FGC6TQnqZ247bADYzTm4SzfprL64Y71cQ46z6s/ORZscbx19d0TXyjKWvBUlraEBQOA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.2.4.tgz",
+      "integrity": "sha512-hVsQ9YFFW8F675ITnNsCfrIMTOYf4JdhceHKx8O40r4xZImXPBnTGYHGh6djBV68ULxxv1dWyCI+1xa/dTjWdg==",
       "dev": true,
       "requires": {
         "@theintern/common": "~0.1.3",
@@ -1857,10 +1873,9 @@
       }
     },
     "arg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
-      "integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -2724,6 +2739,13 @@
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "requires": {
         "callsites": "^2.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+        }
       }
     },
     "caller-id": {
@@ -2744,9 +2766,9 @@
       }
     },
     "callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camel-case": {
       "version": "3.0.0",
@@ -2997,6 +3019,15 @@
             "glob": "^7.1.3"
           }
         }
+      }
+    },
+    "clear-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-3.1.0.tgz",
+      "integrity": "sha512-YEe9OX62MYUMjw16Vf2txyzZ3x2ICXNOrjuZ+06MMhnx3fy7V121h9VA3M3bMTtDg8oEfQ2f/fLuhxrSLXS8uw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       }
     },
     "cli-boxes": {
@@ -3761,6 +3792,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.2.tgz",
+      "integrity": "sha512-a4Z0EJ5Nck6QtMy9ZqloLfpvu2uMV3sBfMCR+CgSBCZc6z5KR4bfEiD3dkepH8iZgJMXQpTqf8FjMmvu/GMFkg==",
+      "requires": {
+        "node-fetch": "2.3.0",
+        "whatwg-fetch": "3.0.0"
       }
     },
     "cross-spawn": {
@@ -4960,9 +5000,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.136",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz",
-      "integrity": "sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ=="
+      "version": "1.3.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+      "integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -7237,6 +7277,11 @@
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -7252,6 +7297,13 @@
       "requires": {
         "caller-path": "^2.0.0",
         "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        }
       }
     },
     "import-from": {
@@ -7260,6 +7312,13 @@
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "requires": {
         "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        }
       }
     },
     "import-lazy": {
@@ -9501,9 +9560,9 @@
       }
     },
     "mdast-util-compact": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
-      "integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
+      "integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
       "requires": {
         "unist-util-visit": "^1.1.0"
       }
@@ -9889,6 +9948,11 @@
         "semver": "^5.4.1"
       }
     },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+    },
     "node-fetch-npm": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
@@ -9946,9 +10010,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.20.tgz",
-      "integrity": "sha512-YnC3NemTLgzOkQTmR4+0yl/7pIsXZcfWXoquNp0Dql03GQ+CYURhnjUDFsSJxpX/Q9nw8lAjLFdnACQoKs6h5w==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+      "integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -10437,6 +10501,14 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
         "no-case": "^2.2.0"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
       }
     },
     "parse-asn1": {
@@ -13212,9 +13284,9 @@
       }
     },
     "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -13449,6 +13521,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "arg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
+          "integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==",
           "dev": true
         },
         "boxen": {
@@ -14552,11 +14630,6 @@
             "strip-indent": "^2.0.0"
           }
         },
-        "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
-        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -14690,9 +14763,9 @@
       "dev": true
     },
     "table": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.3.3.tgz",
-      "integrity": "sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
       "requires": {
         "ajv": "^6.9.1",
         "lodash": "^4.17.11",
@@ -15179,6 +15252,11 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "yn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
         }
       }
     },
@@ -15670,9 +15748,9 @@
       }
     },
     "unist-util-visit-parents": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.0.tgz",
-      "integrity": "sha512-j0XZY3063E6v7qhx4+Q2Z0r8SMrLX7Mr6DabiCy67zMEcFQYtpNOplLlEK1KKEBEs9S+xB5U+yloQxbSwF9P/g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.1.tgz",
+      "integrity": "sha512-/vuqJFrPaWX2QpW3WqOfnvRmqqlPux5BlWMRcUYm8QO5odQJ9XTGoonFYT9hzJXrpT+AmNMKQjK/9xMB5DaLhw==",
       "requires": {
         "unist-util-is": "^2.1.2"
       }
@@ -16565,9 +16643,9 @@
       }
     },
     "yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
+      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "sinon": "~4.5.0"
   },
   "dependencies": {
-    "@dojo/webpack-contrib": "^5.0.2",
+    "@dojo/webpack-contrib": "6.0.0-alpha.2",
     "brotli-webpack-plugin": "1.0.0",
     "chalk": "2.4.1",
     "clean-webpack-plugin": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/cssnano": "4.0.0",
     "@types/execa": "0.8.0",
     "@types/express": "4.11.0",
+    "@types/express-serve-static-core": "4.16.4",
     "@types/globby": "6.1.0",
     "@types/gzip-size": "4.0.0",
     "@types/html-webpack-plugin": "3.2.0",


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add `@types/express-serve-static-core` explicitly which was transitively being installed but not pinned. A patch bump caused a type error in `main.ts`