### PR TITLE
Fix HMR for applications with compressed html

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,6 @@ function serveStatic(app: express.Application, outputDir: string, mode: string, 
 			})
 		);
 	} else {
-		app.use(expressCompression());
 		app.use(express.static(outputDir));
 	}
 }
@@ -143,6 +142,11 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 		}
 		next();
 	});
+
+	const outputDir = (config.output && config.output.path) || process.cwd();
+	if (args.mode !== 'dist' || !Array.isArray(args.compression)) {
+		app.use(expressCompression());
+	}
 	app.use(
 		connectInject({
 			rules: [
@@ -157,8 +161,6 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 			]
 		})
 	);
-
-	const outputDir = (config.output && config.output.path) || process.cwd();
 	serveStatic(app, outputDir, args.mode, args.compression);
 
 	app.use(

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -466,7 +466,7 @@ describe('command', () => {
 					watch: true
 				})
 				.then(() => {
-					assert.strictEqual(useStub.callCount, 8);
+					assert.strictEqual(useStub.callCount, 7);
 					assert.isTrue(
 						hotMiddleware.calledWith(compiler, {
 							heartbeat: 10000


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

HMR stopped working when the size of the `index.html` is greater than 1kb as the content is compressed when the `connect-inject` middleware runs. Move the `connect-inject` middleware to after the express compression middleware to ensure it runs on the uncompressed content.
