### PR TITLE
Set named chunks on to support lazily loading block bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -534,6 +534,12 @@
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true
         },
+        "tslib": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+          "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
+          "dev": true
+        },
         "unzip-response": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
@@ -622,9 +628,9 @@
       }
     },
     "@dojo/framework": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-/tPwqHqmYImAOymGOZ/d65tQt7zZJ9Vy8r6Uwdm6edplmmkygryIVuRjKj7SN+2VsLdexXlnwJ9y+/CZNzBCOA==",
+      "version": "6.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.2.tgz",
+      "integrity": "sha512-+q6FBQyGQ082EbTRUdlMhrc+V5PeQhRxHgxCwjjeQMzvQgdJhPuEgTH6wlJxIf+MJYBR+QJv6Za8hJFxYgGUNg==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
@@ -638,14 +644,14 @@
         "intersection-observer": "0.4.2",
         "pepjs": "0.4.2",
         "resize-observer-polyfill": "1.5.0",
-        "tslib": "1.8.1",
+        "tslib": "1.9.3",
         "web-animations-js": "2.3.1"
       }
     },
     "@dojo/scripts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@dojo/scripts/-/scripts-3.1.0.tgz",
-      "integrity": "sha512-LRUeGVam7IizhvgcRU6zu4bmBXeFzuKcgeleAUHZP1NPa+DROPdidBWIdVeKL5jVHqCnTfYgAqqorsgkftOj2g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dojo/scripts/-/scripts-4.0.0.tgz",
+      "integrity": "sha512-nbJgedsfSAKnapXNrO7QOtwlwQ+2c+SqWSqg+NWodmDfG0ZCiPON/Tw6Xj3VGkChh3RjrdN+kBoaVyiZL9Jx6w==",
       "dev": true,
       "requires": {
         "chalk": "~2.4.0",
@@ -655,7 +661,7 @@
         "rxjs": "^5.5.6",
         "tslint": "~5.11.0",
         "tslint-language-service": "~0.9.9",
-        "typescript": "~2.6.2",
+        "typescript": "3.4.5",
         "yargs": "~10.1.2"
       },
       "dependencies": {
@@ -765,11 +771,11 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "6.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-6.0.0-alpha.2.tgz",
-      "integrity": "sha512-3l6W1EMFnSTYQ41pucAqMWbiBJZk4VkcnXiGQoZdxPpY3DEi7Cb/sObOMpXzPSMs4ND/VqswuFh8U0it1bbnNw==",
+      "version": "6.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-6.0.0-alpha.3.tgz",
+      "integrity": "sha512-asqHWamxIcdj+NCHN59+OlhyUwy9uaBRnwDNSX9ginfiEszIcsREUZp6jAA6tfTlNNyJBT/q6Bp+YCNIU8RlNw==",
       "requires": {
-        "@dojo/framework": "6.0.0-alpha.1",
+        "@dojo/framework": "6.0.0-alpha.2",
         "acorn": "5.3.0",
         "acorn-dynamic-import": "3.0.0",
         "bfj": "6.1.1",
@@ -925,14 +931,6 @@
       "requires": {
         "axios": "~0.18.0",
         "tslib": "~1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-          "dev": true
-        }
       }
     },
     "@theintern/digdug": {
@@ -953,12 +951,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
           "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
           "dev": true
-        },
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-          "dev": true
         }
       }
     },
@@ -971,14 +963,6 @@
         "@theintern/common": "~0.1.3",
         "jszip": "~3.1.5",
         "tslib": "~1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-          "dev": true
-        }
       }
     },
     "@types/anymatch": {
@@ -1161,9 +1145,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
-          "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw=="
+          "version": "12.0.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+          "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw=="
         }
       }
     },
@@ -1282,10 +1266,13 @@
       }
     },
     "@types/jquery": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.16.tgz",
-      "integrity": "sha512-q2WC02YxQoX2nY1HRKlYGHpGP1saPmD7GN0pwCDlTz35a4eOtJG+aHRlXyjCuXokUukSrR2aXyBhSW3j+jPc0A==",
-      "dev": true
+      "version": "3.3.29",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.29.tgz",
+      "integrity": "sha512-FhJvBninYD36v3k6c+bVk1DSZwh7B5Dpb/Pyk3HKVsiohn0nhbefZZ+3JXbWQhFyt0MxSl2jRDdGQPHeOHFXrQ==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
     },
     "@types/jsonfile": {
       "version": "4.0.1",
@@ -1360,9 +1347,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.48.tgz",
-      "integrity": "sha512-velR2CyDrHC1WFheHr5Jm25mdCMs0BXJRp6u0zf8PF9yeOy4Xff5sJeusWS7xOmhAoezlSq8LJ0+9M5H7YkTdw==",
+      "version": "9.6.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.49.tgz",
+      "integrity": "sha512-YY0Okyn4QXC4ugJI+Kng5iWjK8A6eIHiQVaGIhJkyn0YL6Iqo0E0tBC8BuhvYcBK87vykBijM5FtMnCqaa5anA==",
       "dev": true
     },
     "@types/ora": {
@@ -1427,6 +1414,12 @@
         "@types/sinon": "*"
       }
     },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "dev": true
+    },
     "@types/strip-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/strip-ansi/-/strip-ansi-3.0.0.tgz",
@@ -1462,9 +1455,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
-          "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw=="
+          "version": "12.0.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+          "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw=="
         }
       }
     },
@@ -1478,23 +1471,29 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
-          "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw=="
+          "version": "12.0.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+          "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw=="
         }
       }
     },
     "@types/webpack": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.19.tgz",
-      "integrity": "sha512-vO/PuQ9iF9Gy8spN8RUUjt5reu9Z+Tb7iWxeAopCmXaIZaIsOgtY5U6UE2ELlcRUBO1HbNWhy+lQE9G92IJcmQ==",
-      "dev": true,
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.32.tgz",
+      "integrity": "sha512-mNARoaSJTzbiHxtZbf9NULFilu2frqD+g9Iyl9V2jPYJWXi+AC3Hz8lQWPZ5LLtgUm7iF4SDDMB/1bPrbRQgFw==",
       "requires": {
         "@types/anymatch": "*",
         "@types/node": "*",
         "@types/tapable": "*",
         "@types/uglify-js": "*",
         "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.0.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+          "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw=="
+        }
       }
     },
     "@types/webpack-chunk-hash": {
@@ -2129,13 +2128,39 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "dev": true,
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
+        }
       }
     },
     "babel-code-frame": {
@@ -2810,9 +2835,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000971",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
-      "integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g=="
+      "version": "1.0.30000973",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz",
+      "integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -2950,13 +2975,6 @@
       "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "requires": {
         "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-        }
       }
     },
     "ci-info": {
@@ -3193,9 +3211,9 @@
       }
     },
     "color": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
-      "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -4250,6 +4268,12 @@
           "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
           "dev": true
         },
+        "@types/jquery": {
+          "version": "3.2.16",
+          "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.16.tgz",
+          "integrity": "sha512-q2WC02YxQoX2nY1HRKlYGHpGP1saPmD7GN0pwCDlTz35a4eOtJG+aHRlXyjCuXokUukSrR2aXyBhSW3j+jPc0A==",
+          "dev": true
+        },
         "@types/sinon": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.0.0.tgz",
@@ -5005,9 +5029,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
-      "integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw=="
+      "version": "1.3.144",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.144.tgz",
+      "integrity": "sha512-jNRFJpfNrYm5uJ4x0q9oYMOfbL0JPOlkNli8GS/5zEmCjnE5jAtoCo4BYajHiqSPqEeAjtTdItL4p7EZw+jSfg=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -7684,12 +7708,6 @@
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "dev": true
         },
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-          "dev": true
-        },
         "ws": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
@@ -10015,9 +10033,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
-      "integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.22.tgz",
+      "integrity": "sha512-O6XpteBuntW1j86mw6LlovBIwTe+sO2+7vi9avQffNeIW4upgnaCVm6xrBWH+KATz7mNNRNNeEpuWB7dT6Cr3w==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -13281,9 +13299,9 @@
       "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
     },
     "resolve": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -14434,16 +14452,29 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "autoprefixer": {
-          "version": "9.5.1",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
-          "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.0.tgz",
+          "integrity": "sha512-kuip9YilBqhirhHEGHaBTZKXL//xxGnzvsD0FtBQa6z+A69qZD6s/BAX9VzDF1i9VKDquTJDQaPLSEhOnL6FvQ==",
           "requires": {
-            "browserslist": "^4.5.4",
-            "caniuse-lite": "^1.0.30000957",
+            "browserslist": "^4.6.1",
+            "caniuse-lite": "^1.0.30000971",
+            "chalk": "^2.4.2",
             "normalize-range": "^0.1.2",
             "num2fraction": "^1.2.2",
-            "postcss": "^7.0.14",
+            "postcss": "^7.0.16",
             "postcss-value-parser": "^3.3.1"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
           }
         },
         "camelcase": {
@@ -14594,6 +14625,14 @@
                   }
                 }
               }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
             }
           }
         },
@@ -14669,9 +14708,9 @@
           "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
         },
         "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -15266,9 +15305,9 @@
       }
     },
     "tslib": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
-      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
       "version": "5.8.0",
@@ -15509,9 +15548,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "uglify-js": {
@@ -15719,17 +15758,17 @@
       }
     },
     "unist-util-find-all-after": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.3.tgz",
-      "integrity": "sha512-FNPM5Q1AViItYvkLngkalxZ879j842VxGzlfI0gLlgDQz/Teh9CUzqpc7kgFOWO3RK5qU/wqG0UnJ6XWiHSWiA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
+      "integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
       "requires": {
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "^3.0.0"
       }
     },
     "unist-util-is": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-      "integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
     },
     "unist-util-remove-position": {
       "version": "1.1.3",
@@ -15753,11 +15792,11 @@
       }
     },
     "unist-util-visit-parents": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.1.tgz",
-      "integrity": "sha512-/vuqJFrPaWX2QpW3WqOfnvRmqqlPux5BlWMRcUYm8QO5odQJ9XTGoonFYT9hzJXrpT+AmNMKQjK/9xMB5DaLhw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
       "requires": {
-        "unist-util-is": "^2.1.2"
+        "unist-util-is": "^3.0.0"
       }
     },
     "universalify": {
@@ -16037,9 +16076,9 @@
       }
     },
     "vfile-location": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
-      "integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
+      "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ=="
     },
     "vfile-message": {
       "version": "1.1.1",
@@ -16125,25 +16164,6 @@
       "integrity": "sha512-FsOg1RpW2nf3nYpGTy/Qs59RZ7gYG+sI4VrCE8TIBQYh/Kogi04xD39Pj9zUEeUcNx9HeTVPGSO3mtmpLeX9eQ==",
       "requires": {
         "@types/webpack": "^3.0.0 || ^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
-          "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw=="
-        },
-        "@types/webpack": {
-          "version": "4.4.32",
-          "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.32.tgz",
-          "integrity": "sha512-mNARoaSJTzbiHxtZbf9NULFilu2frqD+g9Iyl9V2jPYJWXi+AC3Hz8lQWPZ5LLtgUm7iF4SDDMB/1bPrbRQgFw==",
-          "requires": {
-            "@types/anymatch": "*",
-            "@types/node": "*",
-            "@types/tapable": "*",
-            "@types/uglify-js": "*",
-            "source-map": "^0.6.0"
-          }
-        }
       }
     },
     "webpack-hot-middleware": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@dojo/cli": "^5.0.0",
-    "@dojo/scripts": "~3.1.0",
+    "@dojo/scripts": "~4.0.0",
     "@types/clean-webpack-plugin": "0.1.2",
     "@types/compression": "0.0.36",
     "@types/connect-history-api-fallback": "1.3.1",
@@ -72,6 +72,7 @@
     "@types/gzip-size": "4.0.0",
     "@types/html-webpack-plugin": "3.2.0",
     "@types/http-proxy-middleware": "^0.17.5",
+    "@types/jquery": "3.3.29",
     "@types/jsonfile": "4.0.1",
     "@types/loader-utils": "1.1.3",
     "@types/log-symbols": "2.0.0",
@@ -85,7 +86,7 @@
     "@types/sinon": "~4.3.3",
     "@types/strip-ansi": "3.0.0",
     "@types/tapable": "1.0.4",
-    "@types/webpack": "4.4.19",
+    "@types/webpack": "4.4.32",
     "@types/webpack-chunk-hash": "0.4.2",
     "@types/webpack-manifest-plugin": "1.3.2",
     "@types/yargs": "10.0.0",
@@ -104,7 +105,7 @@
     "sinon": "~4.5.0"
   },
   "dependencies": {
-    "@dojo/webpack-contrib": "6.0.0-alpha.2",
+    "@dojo/webpack-contrib": "6.0.0-alpha.3",
     "brotli-webpack-plugin": "1.0.0",
     "chalk": "2.4.1",
     "clean-webpack-plugin": "1.0.0",

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -42,6 +42,7 @@ function webpackConfig(args: any): webpack.Configuration {
 
 	config.optimization = {
 		...config.optimization,
+		namedChunks: true,
 		minimizer: [new TerserPlugin({ sourceMap: true, cache: true })],
 		flagIncludedChunks: false
 	};

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -26,39 +26,41 @@
         "tslib": "1.8.1",
         "update-notifier": "2.5.0",
         "yargs": "10.1.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+          "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+        }
       }
     },
     "@dojo/framework": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-5.0.0.tgz",
-      "integrity": "sha512-u0iOD6J+B3NynTme54am04Dh/+fK1fiBPnzxbBPa+a/zWyQ0NVs4rCYeM25VUk9nT24WKbKxdBC+4Ssb/24grQ==",
+      "version": "6.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.2.tgz",
+      "integrity": "sha512-+q6FBQyGQ082EbTRUdlMhrc+V5PeQhRxHgxCwjjeQMzvQgdJhPuEgTH6wlJxIf+MJYBR+QJv6Za8hJFxYgGUNg==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
         "@webcomponents/webcomponentsjs": "1.1.0",
         "cldrjs": "0.5.0",
+        "cross-fetch": "3.0.2",
         "css-select-umd": "1.3.0-rc0",
         "diff": "3.5.0",
         "globalize": "1.4.0",
+        "immutable": "3.8.2",
         "intersection-observer": "0.4.2",
         "pepjs": "0.4.2",
         "resize-observer-polyfill": "1.5.0",
-        "tslib": "1.8.1",
-        "web-animations-js": "2.3.1",
-        "whatwg-fetch": "3.0.0"
-      }
-    },
-    "@dojo/themes": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@dojo/themes/-/themes-5.0.0.tgz",
-      "integrity": "sha512-LRa6sPbDA5TqPc+kaE2Ztqesx5j7z84DZYaLAI4jJoKFjetJN/ZHoiSOAJQ5wSCLbeDXdMAlRIRSiRfCPiHQBQ=="
-    },
-    "@dojo/widgets": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@dojo/widgets/-/widgets-5.0.0.tgz",
-      "integrity": "sha512-rbHjBypPcaD2RsgFA5IjDRUfGWj23H2dnGNsxlovTQ+01wR0BbycoQ8P6khH/7OOzZFiQ5vIOdSQQElyqKAFsA==",
-      "requires": {
-        "tslib": "~1.8.1"
+        "tslib": "1.9.3",
+        "web-animations-js": "2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
       }
     },
     "@fortawesome/fontawesome-free": {
@@ -378,6 +380,15 @@
         "capture-stack-trace": "^1.0.0"
       }
     },
+    "cross-fetch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.2.tgz",
+      "integrity": "sha512-a4Z0EJ5Nck6QtMy9ZqloLfpvu2uMV3sBfMCR+CgSBCZc6z5KR4bfEiD3dkepH8iZgJMXQpTqf8FjMmvu/GMFkg==",
+      "requires": {
+        "node-fetch": "2.3.0",
+        "whatwg-fetch": "3.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -406,9 +417,9 @@
       }
     },
     "css-what": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
-      "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "cyclist": {
       "version": "0.2.2",
@@ -459,19 +470,12 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-        }
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "domelementtype": {
@@ -544,13 +548,13 @@
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
     },
     "es5-ext": {
-      "version": "0.10.47",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.47.tgz",
-      "integrity": "sha512-/1TItLfj+TTfWoeRcDn/0FbGV6SNo4R+On2GGVucPU/j3BWnXE2Co8h8CTo4Tu34gFJtnmwS9xiScKs4EjZhdw==",
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
@@ -857,6 +861,11 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -1180,6 +1189,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "node-fetch-npm": {
       "version": "2.0.2",
@@ -1795,9 +1809,9 @@
       }
     },
     "tslib": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
-      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -1805,9 +1819,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
-      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE="
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,12 +15,10 @@
   "license": "ISC",
   "dependencies": {
     "@dojo/cli": "^5.0.0",
-    "@dojo/framework": "^5.0.0",
-    "@dojo/widgets": "^5.0.0",
-    "@dojo/themes": "^5.0.0",
+    "@dojo/framework": "6.0.0-alpha.2",
     "@fortawesome/fontawesome-free": "5.3.1",
-    "tslib": "~1.8.0",
-    "typescript": "2.6.1"
+    "tslib": "~1.9.1",
+    "typescript": "~3.4.5"
   },
   "devDependencies": {
     "shx": "0.2.2"

--- a/test-app/src/ChildRoutedWidget.ts
+++ b/test-app/src/ChildRoutedWidget.ts
@@ -1,3 +1,3 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
 
 export default class ChildRoutedWidget extends WidgetBase {}

--- a/test-app/src/LazyApp.ts
+++ b/test-app/src/LazyApp.ts
@@ -1,12 +1,9 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Outlet from '@dojo/framework/routing/Outlet';
 import LazyWidget from './LazyWidget';
 import StaticAssetWidget from './StaticAssetWidget';
 import RoutedWidget from './RoutedWidget';
-import theme from '@dojo/themes/dojo';
-import Button from '@dojo/widgets/button';
-import Icon from '@dojo/widgets/icon';
 
 import * as css from './app.m.css';
 
@@ -23,8 +20,7 @@ export default class Projector extends WidgetBase<any> {
 				}
 			}),
 			v('a', { href: '' }, ['link']),
-			v('i', { classes: ['fab', 'fa-d-and-d'] }),
-			v('div', { id: 'dojo-theme' }, [w(Button, { theme, popup: true }, [w(Icon, { theme, type: 'mailIcon' })])])
+			v('i', { classes: ['fab', 'fa-d-and-d'] })
 		]);
 	}
 }

--- a/test-app/src/LazyWidget.ts
+++ b/test-app/src/LazyWidget.ts
@@ -1,5 +1,5 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v } from '@dojo/framework/widget-core/d';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v } from '@dojo/framework/core/vdom';
 
 export default class LazyWidget extends WidgetBase {
 	render() {

--- a/test-app/src/RoutedWidget.ts
+++ b/test-app/src/RoutedWidget.ts
@@ -1,7 +1,7 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
 import ChildRoutedWidget from './ChildRoutedWidget';
 import Outlet from '@dojo/framework/routing/Outlet';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 export default class RoutedWidget extends WidgetBase {
 	protected render() {

--- a/test-app/src/StaticAssetWidget.ts
+++ b/test-app/src/StaticAssetWidget.ts
@@ -1,5 +1,5 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v } from '@dojo/framework/widget-core/d';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v } from '@dojo/framework/core/vdom';
 
 export default class PublicAssetWidget extends WidgetBase {
 	render() {

--- a/test-app/src/app.m.css
+++ b/test-app/src/app.m.css
@@ -1,6 +1,5 @@
 @import '../external/test-theme/variables.css';
 @import './variables.css';
-@import '~@dojo/themes/dojo/variables.css';
 
 .root {
 	composes: root from '../external/test-theme/theme.m.css';

--- a/test-app/src/main.css
+++ b/test-app/src/main.css
@@ -1,5 +1,4 @@
 @import '~@fortawesome/fontawesome-free/css/all.css';
-@import '~@dojo/themes/dojo/index.css';
 
 .app {
 	background: purple;

--- a/test-app/src/main.ts
+++ b/test-app/src/main.ts
@@ -1,17 +1,13 @@
-import has from '@dojo/framework/has/has';
-import renderer from '@dojo/framework/widget-core/vdom';
-import { w } from '@dojo/framework/widget-core/d';
-import Registry from '@dojo/framework/widget-core/Registry';
+import has from '@dojo/framework/core/has';
+import renderer, { w } from '@dojo/framework/core/vdom';
+import Registry from '@dojo/framework/core/Registry';
 import { registerRouterInjector } from '@dojo/framework/routing/RouterInjector';
 import App from './App';
 import * as css from './app.m.css';
 import './Bar';
 import LazyApp from './LazyApp';
 import routes from './routes';
-import myTheme from './themes/test-app/theme';
 import test from './test.block';
-
-console.log(myTheme);
 
 '!has("bar")';
 

--- a/test-app/src/main.ts
+++ b/test-app/src/main.ts
@@ -39,7 +39,9 @@ if (btr) {
 } else {
 	const nodeBtrCache = document.createElement('div');
 	nodeBtrCache.id = 'nodeBtrCache';
-	nodeBtrCache.innerHTML = test('./src/foo.txt');
+	test('./src/foo.txt').then((result: string) => {
+		nodeBtrCache.innerHTML = result;
+	});
 	root!.appendChild(nodeBtrCache);
 }
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Turns on the named chunks optimization setting to support lazily loading block bundles.

Updates dependencies required for the latest release of webpack-contrib

Related to https://github.com/dojo/webpack-contrib/issues/155
