### PR TITLE
Experimental speed flag

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -16,7 +16,6 @@ import * as ManifestPlugin from 'webpack-manifest-plugin';
 
 const postcssPresetEnv = require('postcss-preset-env');
 const postcssImport = require('postcss-import');
-const IgnorePlugin = require('webpack/lib/IgnorePlugin');
 const slash = require('slash');
 const WrapperPlugin = require('wrapper-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -171,10 +170,16 @@ function loadRoutingOutlets() {
 
 export default function webpackConfigFactory(args: any): webpack.Configuration {
 	tsnode.register();
-	const extensions = args.legacy ? ['.ts', '.tsx', '.js'] : ['.ts', '.tsx', '.mjs', '.js'];
-	const compilerOptions = args.legacy ? {} : { target: 'es6', module: 'esnext' };
-	let features = args.legacy ? args.features : { ...(args.features || {}), ...getFeatures('modern') };
+	const isExperimentalSpeed = !!args.experimental.speed && args.dev;
+	const isLegacy = args.legacy && !isExperimentalSpeed;
+	const isTest = args.mode === 'unit' || args.mode === 'functional' || args.mode === 'test';
+	const singleBundle = args.singleBundle || isTest || isExperimentalSpeed;
+	const watch = args.watch;
+	const extensions = isLegacy ? ['.ts', '.tsx', '.js'] : ['.ts', '.tsx', '.mjs', '.js'];
+	const compilerOptions = isLegacy ? {} : { target: 'es6', module: 'esnext' };
+	let features = isLegacy ? args.features : { ...(args.features || {}), ...getFeatures('modern') };
 	features = { ...features, 'dojo-debug': false };
+
 	const assetsDir = path.join(process.cwd(), 'assets');
 	const assetsDirPattern = new RegExp(assetsDir);
 	const lazyModules = Object.keys(args.bundles || {}).reduce(
@@ -184,9 +189,6 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		},
 		[] as string[]
 	);
-	const isTest = args.mode === 'unit' || args.mode === 'functional' || args.mode === 'test';
-	const singleBundle = args.singleBundle || isTest;
-	const watch = args.watch;
 	const watchExtraFiles = Array.isArray(args.watchExtraFiles) ? args.watchExtraFiles : [];
 	let entry: any;
 	if (!isTest) {
@@ -220,13 +222,14 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		customTransformers.push(registryTransformer(basePath, lazyModules, false, outlets));
 	}
 
-	if (!args.legacy && !singleBundle) {
+	if (!isLegacy && !singleBundle) {
 		customTransformers.push(importTransformer(basePath, args.bundles));
 	}
 
 	const tsLoaderOptions: any = {
 		onlyCompileBundledFiles: true,
 		instance: 'dojo',
+		transpileOnly: isExperimentalSpeed,
 		compilerOptions,
 		getCustomTransformers() {
 			return { before: customTransformers };
@@ -255,7 +258,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	};
 
 	const postcssPresetConfig = {
-		browsers: args.legacy ? ['last 2 versions', 'ie >= 10'] : ['last 2 versions'],
+		browsers: isLegacy ? ['last 2 versions', 'ie >= 10'] : ['last 2 versions'],
 		insertBefore: {
 			'color-mod-function': colorToColorMod
 		},
@@ -264,7 +267,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 			'nesting-rules': true
 		},
 		autoprefixer: {
-			grid: args.legacy
+			grid: isLegacy
 		}
 	};
 
@@ -280,13 +283,6 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				localIdentName: '[name]__[local]__[hash:base64:5]',
 				getLocalIdent
 			}
-		},
-		{
-			loader: 'postcss-loader?sourceMap',
-			options: {
-				ident: 'postcss',
-				plugins: [postcssImport(postcssImportConfig), postcssPresetEnv(postcssPresetConfig)]
-			}
 		}
 	];
 
@@ -298,15 +294,25 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				sourceMap: true,
 				importLoaders: 1
 			}
-		},
-		{
+		}
+	];
+
+	if (!isExperimentalSpeed) {
+		postCssModuleLoader.push({
 			loader: 'postcss-loader?sourceMap',
 			options: {
 				ident: 'postcss',
 				plugins: [postcssImport(postcssImportConfig), postcssPresetEnv(postcssPresetConfig)]
 			}
-		}
-	];
+		});
+		cssLoader.push({
+			loader: 'postcss-loader?sourceMap',
+			options: {
+				ident: 'postcss',
+				plugins: [postcssImport(postcssImportConfig), postcssPresetEnv(postcssPresetConfig)]
+			}
+		});
+	}
 
 	const config: webpack.Configuration = {
 		mode: 'development',
@@ -403,7 +409,6 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					maxChunks: 1
 				}),
 			new CssModulePlugin(basePath),
-			new IgnorePlugin(/request\/providers\/node/),
 			new MiniCssExtractPlugin({
 				filename: '[name].css'
 			}),
@@ -423,17 +428,18 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				new webpack.DefinePlugin({
 					__MAIN_ENTRY: JSON.stringify(mainEntryPath)
 				}),
-			new OptimizeCssAssetsPlugin({
-				cssProcessor: cssnano,
-				cssProcessorOptions: {
-					map: {
-						inline: false
+			!isExperimentalSpeed &&
+				new OptimizeCssAssetsPlugin({
+					cssProcessor: cssnano,
+					cssProcessorOptions: {
+						map: {
+							inline: false
+						}
+					},
+					cssProcessorPluginOptions: {
+						preset: ['default', { calc: false }]
 					}
-				},
-				cssProcessorPluginOptions: {
-					preset: ['default', { calc: false }]
-				}
-			}),
+				}),
 			!singleBundle &&
 				new BootstrapPlugin({
 					entryPath: mainEntryPath,
@@ -514,7 +520,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 							loader: '@dojo/webpack-contrib/static-build-loader',
 							options: { features }
 						},
-						args.legacy && getUMDCompatLoader({ bundles: args.bundles }),
+						isLegacy && getUMDCompatLoader({ bundles: args.bundles }),
 						{
 							loader: 'ts-loader',
 							options: tsLoaderOptions

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -170,7 +170,7 @@ function loadRoutingOutlets() {
 
 export default function webpackConfigFactory(args: any): webpack.Configuration {
 	tsnode.register();
-	const isExperimentalSpeed = !!args.experimental.speed && args.dev;
+	const isExperimentalSpeed = !!args.experimental.speed && args.mode === 'dev';
 	const isLegacy = args.legacy && !isExperimentalSpeed;
 	const isTest = args.mode === 'unit' || args.mode === 'functional' || args.mode === 'test';
 	const singleBundle = args.singleBundle || isTest || isExperimentalSpeed;

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -15,6 +15,9 @@ import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 const WebpackPwaManifest = require('webpack-pwa-manifest');
 
 function webpackConfig(args: any): webpack.Configuration {
+	const isExperimentalSpeed = !!args.experimental.speed;
+	const singleBundle = args.singleBundle || isExperimentalSpeed;
+
 	const basePath = process.cwd();
 	const config = baseConfigFactory(args);
 	const manifest: WebAppManifest = args.pwa && args.pwa.manifest;
@@ -23,7 +26,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	const outputPath = path.join(output!.path!, 'dev');
 	const assetsDir = path.join(process.cwd(), 'assets');
 	const assetsDirExists = fs.existsSync(assetsDir);
-	const entryName = args.singleBundle ? mainEntry : bootstrapEntry;
+	const entryName = singleBundle ? mainEntry : bootstrapEntry;
 
 	config.plugins = [
 		...plugins!,

--- a/src/main.ts
+++ b/src/main.ts
@@ -326,9 +326,9 @@ const command: Command = {
 	run(helper: Helper, args: any) {
 		console.log = () => {};
 		let config: webpack.Configuration;
+		args.experimental = args.experimental || {};
 		let { feature, ...remainingArgs } = args;
 		remainingArgs = { ...remainingArgs, features: { ...remainingArgs.features, ...feature } };
-		args.experimental = args.experimental || {};
 
 		if (args.mode === 'dev') {
 			config = devConfigFactory(remainingArgs);

--- a/src/main.ts
+++ b/src/main.ts
@@ -284,13 +284,13 @@ const command: Command = {
 		});
 
 		options('single-bundle', {
-			describe: 'Limits the built output to single bundle',
+			describe: 'limits the built output to a single bundle',
 			default: false,
 			type: 'boolean'
 		});
 
 		options('omit-hash', {
-			describe: 'Omits hashes from output file names in dist mode',
+			describe: 'omits hashes from output file names in dist mode',
 			defaultDescription: '(always false for dev builds)',
 			default: false,
 			type: 'boolean'
@@ -304,7 +304,7 @@ const command: Command = {
 		});
 
 		options('feature', {
-			describe: 'List of features to include',
+			describe: 'list of has() features to include',
 			alias: 'f',
 			array: true,
 			coerce: (args: string[]) => {
@@ -328,6 +328,8 @@ const command: Command = {
 		let config: webpack.Configuration;
 		let { feature, ...remainingArgs } = args;
 		remainingArgs = { ...remainingArgs, features: { ...remainingArgs.features, ...feature } };
+		args.experimental = args.experimental || {};
+
 		if (args.mode === 'dev') {
 			config = devConfigFactory(remainingArgs);
 		} else if (args.mode === 'unit' || args.mode === 'test') {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -189,7 +189,7 @@ describe('command', () => {
 			.then(() => {
 				assert.isTrue(mockDistConfig.called);
 				assert.deepEqual(mockDistConfig.firstCall.args, [
-					{ mode: 'dist', features: { foo: true, bar: false } }
+					{ experimental: {}, mode: 'dist', features: { foo: true, bar: false } }
 				]);
 			});
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/)

Adds an `experimental` options bag for the `.dojorc`. Adds a flag called `speed`, produces a much quicker build in `dev` mode at the cost of:

* no typechecking
* no legacy support
* no codesplitting
* no postcss support
* no cssnano

This flag is automatically disabled when in any other mode other than `dev`.

In very large projects this can mean significant gains in both cold builds and watch builds during development. An example large project -
without experimental speed flag:
```sh
$ time dojo build -m dev
 106.02 real       150.63 user         5.29 sys
```
with experimental speed flag:
```sh
$ time dojo build -m dev
29.01 real        46.77 user         2.26 sys
```