### PR TITLE
Disable experimental speed mode when legacy is enabled

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -170,8 +170,8 @@ function loadRoutingOutlets() {
 
 export default function webpackConfigFactory(args: any): webpack.Configuration {
 	tsnode.register();
-	const isExperimentalSpeed = !!args.experimental.speed && args.mode === 'dev';
-	const isLegacy = args.legacy && !isExperimentalSpeed;
+	const isLegacy = args.legacy;
+	const isExperimentalSpeed = !!args.experimental.speed && args.mode === 'dev' && !isLegacy;
 	const isTest = args.mode === 'unit' || args.mode === 'functional' || args.mode === 'test';
 	const singleBundle = args.singleBundle || isTest || isExperimentalSpeed;
 	const watch = args.watch;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/)


**Description:**
Only support experimental speed mode when not in legacy, rather than disabling legacy.
