### PR TITLE
Conditionally import eventsource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -838,9 +838,9 @@
           "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
         },
         "ts-node": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.2.0.tgz",
-          "integrity": "sha512-m8XQwUurkbYqXrKqr3WHCW310utRNvV5OnRVeISeea7LoCWVcdfeB/Ntl8JYWFh+WRoUAdBgESrzKochQt7sMw==",
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
+          "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
           "requires": {
             "arg": "^4.1.0",
             "diff": "^4.0.1",
@@ -899,9 +899,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
-      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
@@ -3311,21 +3311,21 @@
       },
       "dependencies": {
         "cacache": {
-          "version": "11.3.2",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-          "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+          "version": "11.3.3",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+          "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
           "requires": {
-            "bluebird": "^3.5.3",
+            "bluebird": "^3.5.5",
             "chownr": "^1.1.1",
             "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.3",
+            "glob": "^7.1.4",
             "graceful-fs": "^4.1.15",
             "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "move-concurrently": "^1.0.1",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
+            "rimraf": "^2.6.3",
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
@@ -5030,9 +5030,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.159",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.159.tgz",
-      "integrity": "sha512-bhiEr8/A97GUBcUzNb9MFNhzQOjakbKmEKBEAa6UMY45zG2e8PM63LOgAPXEJE9bQiaQH6nOdYiYf8X821tZjQ=="
+      "version": "1.3.164",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.164.tgz",
+      "integrity": "sha512-VLlalqUeduN4+fayVtRZvGP2Hl1WrRxlwzh2XVVMJym3IFrQUS29BFQ1GP/BxOJXJI1OFCrJ5BnFEsAe8NHtOg=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -5308,11 +5308,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
       "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
-    },
-    "eventsource-polyfill": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/eventsource-polyfill/-/eventsource-polyfill-0.9.6.tgz",
-      "integrity": "sha1-EODRh/ERsWfyj9q5GIQ859gY8Tw="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -9453,22 +9448,22 @@
       },
       "dependencies": {
         "cacache": {
-          "version": "11.3.2",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-          "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+          "version": "11.3.3",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+          "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.3",
+            "bluebird": "^3.5.5",
             "chownr": "^1.1.1",
             "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.3",
+            "glob": "^7.1.4",
             "graceful-fs": "^4.1.15",
             "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "move-concurrently": "^1.0.1",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
+            "rimraf": "^2.6.3",
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
@@ -9511,6 +9506,15 @@
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
           }
         },
         "ssri": {
@@ -14808,9 +14812,9 @@
       "dev": true
     },
     "table": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
-      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.1.tgz",
+      "integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
       "requires": {
         "ajv": "^6.9.1",
         "lodash": "^4.17.11",
@@ -14955,21 +14959,21 @@
       },
       "dependencies": {
         "cacache": {
-          "version": "11.3.2",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-          "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+          "version": "11.3.3",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+          "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
           "requires": {
-            "bluebird": "^3.5.3",
+            "bluebird": "^3.5.5",
             "chownr": "^1.1.1",
             "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.3",
+            "glob": "^7.1.4",
             "graceful-fs": "^4.1.15",
             "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "move-concurrently": "^1.0.1",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
+            "rimraf": "^2.6.3",
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "connect-inject": "0.4.0",
     "css-loader": "1.0.1",
     "cssnano": "4.1.7",
-    "eventsource-polyfill": "0.9.6",
     "express": "4.16.2",
     "express-static-gzip": "1.1.3",
     "extra-watch-webpack-plugin": "1.0.3",

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,11 +105,7 @@ function buildNpmDependencies(): any {
 function fileWatch(config: webpack.Configuration, args: any, app?: express.Application): Promise<void> {
 	let compiler: webpack.Compiler;
 	if (args.serve && app) {
-		const entry = config.entry as any;
 		const timeout = 20 * 1000;
-		Object.keys(entry).forEach((name) => {
-			entry[name].unshift('eventsource-polyfill');
-		});
 		compiler = createWatchCompiler(config);
 		app.use(hotMiddleware(compiler, { heartbeat: timeout / 2 }));
 	} else {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -475,19 +475,6 @@ describe('command', () => {
 				});
 		});
 
-		it('enables hot module replacement watch', () => {
-			const main = mockModule.getModuleUnderTest().default;
-			return main
-				.run(getMockConfiguration(), {
-					mode: 'dev',
-					serve: true,
-					watch: true
-				})
-				.then(() => {
-					assert.sameMembers(entry.main, ['eventsource-polyfill']);
-				});
-		});
-
 		it('serves compressed files in dist mode', () => {
 			const expressStaticGzip = mockModule.getMock('express-static-gzip').ctor;
 			const main = mockModule.getModuleUnderTest().default;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

event source will be conditionally loaded and included in the client bundle with the next release of webpack-contrib