### PR TITLE
Warn on child selectors in stylelint

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -406,14 +406,18 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				config: {
 					rules: {
 						'selector-max-type': [0, { ignoreTypes: '.' }],
-						'selector-max-universal': [0]
+						'selector-max-universal': [0],
+						'selector-pseudo-class-blacklist': ['/-child$/']
 					}
 				},
 				emitErrors: false,
 				formatter: (results: any) => {
 					return stylelint.formatters
 						.string(results)
-						.replace(/selector-max-type|selector-max-universal/g, 'css-modules')
+						.replace(
+							/selector-max-type|selector-max-universal|selector-pseudo-class-blacklist/g,
+							'css-modules'
+						)
 						.replace(
 							/to have no more than (\d*) type selectors/g,
 							'to not contain element selectors due to unsafe isolation'


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [x] All code has been formatted with [`prettier`](https://prettier.io/)

**Description:**
Should warn on all child selectors such as nth-child, first-child, last-child, as they are unsafe for css modules.
