### PR TITLE
Adding trailing slash to base url if it does not exist

### DIFF
--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -17,7 +17,7 @@ const WebpackPwaManifest = require('webpack-pwa-manifest');
 function webpackConfig(args: any): webpack.Configuration {
 	const isExperimentalSpeed = !!args.experimental.speed;
 	const singleBundle = args.singleBundle || isExperimentalSpeed;
-	const base = args.base || '/';
+	const base = (args.base || '').replace(/(?<!\/)$/, '/');
 
 	const basePath = process.cwd();
 	const config = baseConfigFactory(args);

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -29,7 +29,7 @@ All rights reserved
 
 function webpackConfig(args: any): webpack.Configuration {
 	const basePath = process.cwd();
-	const base = args.base || '/';
+	const base = (args.base || '').replace(/(?<!\/)$/, '/');
 	const config = baseConfigFactory(args);
 	const manifest: WebAppManifest = args.pwa && args.pwa.manifest;
 	const { plugins, output } = config;

--- a/test-app/.dojorc-dev-app
+++ b/test-app/.dojorc-dev-app
@@ -1,6 +1,6 @@
 {
 	"build-app": {
-		"base": "/test-app/output/dev-app/",
+		"base": "/test-app/output/dev-app",
 		"mode": "dev",
 		"legacy": true,
 		"compression": [ "gzip", "brotli" ],


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

When using the base path, you had to specify the trailing `/` at the end of the path. This is no longer required. The path `/` will be added if it is not there.

Tested this with a local dojo app and confirmed that the `/` is added automatically.

Resolves #306 
