### PR TITLE
Use a percentage of total chunks to determine which chunk to include the module in

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -252,6 +252,9 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		customTransformers.push(registryTransformer(basePath, lazyModules, false, outlets));
 	}
 
+	const chunkCount = lazyModules.length + outlets.length;
+	const chunkPercentageThreshold = chunkCount > 0 ? 40 : 0;
+
 	if (!isLegacy && !singleBundle) {
 		customTransformers.push(importTransformer(basePath, args.bundles));
 	}
@@ -420,7 +423,12 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 									) {
 										return false;
 									}
-									if (chunks.length > 1) {
+									const chunkPercentage = chunkCount
+										? Math.floor((chunks.length / chunkCount) * 100)
+										: 0;
+									if (
+										chunkPercentage ? chunkPercentage > chunkPercentageThreshold : chunks.length > 2
+									) {
 										return true;
 									}
 									return false;

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -253,7 +253,14 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	}
 
 	const chunkCount = lazyModules.length + outlets.length;
-	const chunkPercentageThreshold = chunkCount > 0 ? 40 : 0;
+	let chunkPercentageThreshold = 0;
+	if (chunkCount >= 10) {
+		chunkPercentageThreshold = 25;
+	} else if (chunkCount >= 5) {
+		chunkPercentageThreshold = 30;
+	} else if (chunkCount > 0) {
+		chunkPercentageThreshold = 40;
+	}
 
 	if (!isLegacy && !singleBundle) {
 		customTransformers.push(importTransformer(basePath, args.bundles));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

As part of Dojo 6, changes to the bundle optimisation meant that any module included in more than one bundle other than the `runtime/*` and `main` bundles would be included in the `main` bundle. However as good intentioned as this is, as it means most larger apps _do_ ship less overall javascript to the UI, it means that there is often code included in the main bundle that could never be used.

This proposal changes the algorithm to use a percentage of known bundles looking at the top level routes and the `dojorc` configuration, to determine whether to include the module in the main bundle. The percentage of bundles a module is required to belong to is calculated on a sliding scale based on the total number of bundles for the app.

| Bundle Count | Percentage |
| ------------- | ------------ |
| >= 10             | 25%              |
| >= 5 < 10      | 30%              |
| < 5                 | 40%              |

If the number of total bundles cannot be determined it falls back to the module belonging to more than 2 bundles.
