### PR TITLE
Do not process external css modules

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -617,12 +617,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				},
 				{
 					test: /\.css$/,
-					exclude: (path: string) => {
-						if (path.indexOf(srcPath) > -1 || path.indexOf(testPath) > -1) {
-							return true;
-						}
-						return /\.m\.css$/.test(path) && !/.*(\/|\\)node_modules(\/|\\).*/.test(path);
-					},
+					include: /.*(\/|\\)node_modules(\/|\\).*/,
 					use: [
 						MiniCssExtractPlugin.loader,
 						{

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -621,10 +621,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 						if (path.indexOf(srcPath) > -1 || path.indexOf(testPath) > -1) {
 							return true;
 						}
-						return (
-							/\.m\.css$/.test(path) &&
-							!/.*(\/|\\)node_modules(\/|\\)@dojo(\/|\\)widgets(\/|\\).*/.test(path)
-						);
+						return /\.m\.css$/.test(path) && !/.*(\/|\\)node_modules(\/|\\).*/.test(path);
 					},
 					use: [
 						MiniCssExtractPlugin.loader,
@@ -644,7 +641,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					oneOf: [{ issuer: indexHtmlPattern, use: 'identity-loader' }, { use: cssLoader }]
 				},
 				{
-					exclude: /.*(\/|\\)node_modules(\/|\\)@dojo(\/|\\)widgets(\/|\\).*/,
+					include: allPaths,
 					test: /\.m\.css$/,
 					use: postCssModuleLoader
 				}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

At the moment css modules from node_modules are being processed for everything except `@dojo/widgets`, however we should not be processing css modules from external dependencies, instead we should be simply loading them.

This is causing any widgets being built using `@dojo/cli-build-widget` to have their css modules processed for a second time.

Resolves #312