### PR TITLE
Set public path to match the base config options for mini css loader

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -297,6 +297,13 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		}
 	};
 
+	const miniCssExtractLoader = {
+		loader: MiniCssExtractPlugin.loader,
+		options: {
+			publicPath: args.base === undefined ? '/' : args.base
+		}
+	};
+
 	const postcssPresetConfig = {
 		browsers: isLegacy ? ['last 2 versions', 'ie >= 10'] : ['last 2 versions'],
 		insertBefore: {
@@ -312,7 +319,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	};
 
 	const postCssModuleLoader = [
-		MiniCssExtractPlugin.loader,
+		miniCssExtractLoader,
 		'@dojo/webpack-contrib/css-module-decorator-loader',
 		{
 			loader: 'css-loader',
@@ -327,7 +334,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	];
 
 	const cssLoader = [
-		MiniCssExtractPlugin.loader,
+		miniCssExtractLoader,
 		{
 			loader: 'css-loader',
 			options: {
@@ -634,7 +641,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					test: /\.css$/,
 					include: /.*(\/|\\)node_modules(\/|\\).*/,
 					use: [
-						MiniCssExtractPlugin.loader,
+						miniCssExtractLoader,
 						{
 							loader: 'css-loader',
 							options: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Sets the `publicPath` of the mini CSS loader to the dojorc base option, defaulting to `/`. This ensure that assets can be loaded from code split CSS.

Resolves #315 
