### PR TITLE
Use relative path for mini css assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10172,13 +10172,27 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.2.tgz",
-      "integrity": "sha512-ots7URQH4wccfJq9Ssrzu2+qupbncAce4TmTzunI9CIwlQMp2XI+WNUw6xWF6MMAGAm1cbUVINrSjATaVMyKXg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
+      "integrity": "sha512-MNpRGbNA52q6U92i0qbVpQNsgk7LExy41MdAlG84FeytfDOtRIf/mCHdEgG8rpTKOaNKiqUnZdlptF469hxqOw==",
       "requires": {
         "loader-utils": "^1.1.0",
+        "normalize-url": "1.9.1",
         "schema-utils": "^1.0.0",
         "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+          "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+          "requires": {
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
+          }
+        }
       }
     },
     "minimalistic-assert": {
@@ -13215,6 +13229,14 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -13227,6 +13249,15 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -13799,6 +13830,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -14454,6 +14486,14 @@
         }
       }
     },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -14689,6 +14729,11 @@
       "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-argv": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "loader-utils": "1.1.0",
     "log-symbols": "2.1.0",
     "log-update": "2.3.0",
-    "mini-css-extract-plugin": "0.4.2",
+    "mini-css-extract-plugin": "0.8.0",
     "minimatch": "3.0.4",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "ora": "1.3.0",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -312,8 +312,17 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		}
 	};
 
+	const miniCssExtractLoader: any = {
+		loader: MiniCssExtractPlugin.loader,
+		options: {
+			publicPath: (resourcePath: any, context: any) => {
+				return path.relative(path.dirname(resourcePath), context) + '/';
+			}
+		}
+	};
+
 	const postCssModuleLoader = [
-		MiniCssExtractPlugin.loader,
+		miniCssExtractLoader,
 		'@dojo/webpack-contrib/css-module-decorator-loader',
 		{
 			loader: 'css-loader',
@@ -328,7 +337,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	];
 
 	const cssLoader = [
-		MiniCssExtractPlugin.loader,
+		miniCssExtractLoader,
 		{
 			loader: 'css-loader',
 			options: {
@@ -635,7 +644,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					test: /\.css$/,
 					include: /.*(\/|\\)node_modules(\/|\\).*/,
 					use: [
-						MiniCssExtractPlugin.loader,
+						miniCssExtractLoader,
 						{
 							loader: 'css-loader',
 							options: {

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -298,13 +298,6 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		}
 	};
 
-	const miniCssExtractLoader: any = {
-		loader: MiniCssExtractPlugin.loader,
-		options: {
-			publicPath: args.base === undefined ? '/' : args.base
-		}
-	};
-
 	const postcssPresetConfig = {
 		browsers: isLegacy ? ['last 2 versions', 'ie >= 10'] : ['last 2 versions'],
 		insertBefore: {
@@ -320,7 +313,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	};
 
 	const postCssModuleLoader = [
-		miniCssExtractLoader,
+		MiniCssExtractPlugin.loader,
 		'@dojo/webpack-contrib/css-module-decorator-loader',
 		{
 			loader: 'css-loader',
@@ -335,7 +328,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	];
 
 	const cssLoader = [
-		miniCssExtractLoader,
+		MiniCssExtractPlugin.loader,
 		{
 			loader: 'css-loader',
 			options: {
@@ -642,7 +635,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					test: /\.css$/,
 					include: /.*(\/|\\)node_modules(\/|\\).*/,
 					use: [
-						miniCssExtractLoader,
+						MiniCssExtractPlugin.loader,
 						{
 							loader: 'css-loader',
 							options: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR

**Description:**

Using the default `/` base breaks any applications that load from a directory as it will try and request the assets from the webservers root. This change calculates the relative directories back to the asset and prepends the asset url.