### PR TITLE
Revert "Set public path to match the base config options for mini css loader (#316)

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -298,13 +298,6 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		}
 	};
 
-	const miniCssExtractLoader: any = {
-		loader: MiniCssExtractPlugin.loader,
-		options: {
-			publicPath: args.base === undefined ? '/' : args.base
-		}
-	};
-
 	const postcssPresetConfig = {
 		browsers: isLegacy ? ['last 2 versions', 'ie >= 10'] : ['last 2 versions'],
 		insertBefore: {
@@ -320,7 +313,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	};
 
 	const postCssModuleLoader = [
-		miniCssExtractLoader,
+		MiniCssExtractPlugin.loader,
 		'@dojo/webpack-contrib/css-module-decorator-loader',
 		{
 			loader: 'css-loader',
@@ -335,7 +328,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	];
 
 	const cssLoader = [
-		miniCssExtractLoader,
+		MiniCssExtractPlugin.loader,
 		{
 			loader: 'css-loader',
 			options: {
@@ -642,7 +635,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					test: /\.css$/,
 					include: /.*(\/|\\)node_modules(\/|\\).*/,
 					use: [
-						miniCssExtractLoader,
+						MiniCssExtractPlugin.loader,
 						{
 							loader: 'css-loader',
 							options: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Setting the public path for the mini css loader causes issues for applications that serve the static from a directory by using the `window.__public_origin__` (normally from a CDN), as the asset is not located at the root of the CDN.

This reverts commit 9bad4bcec855f3004c0eecd201714ec8bfa8e250.

This reopens the issue the commit attempted to resolve, further investigation is required to determine the correct behaviour in all asset scenarios.