### PR TITLE
Use transpile only with tsnode

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -191,7 +191,7 @@ export class InsertScriptPlugin {
 }
 
 export default function webpackConfigFactory(args: any): webpack.Configuration {
-	tsnode.register();
+	tsnode.register({ transpileOnly: true });
 	const isLegacy = args.legacy;
 	const experimental = args.experimental || {};
 	const isExperimentalSpeed = !!experimental.speed && args.mode === 'dev' && !isLegacy;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Use `transpileOnly` with tsnode.

Resolves #332 
