### PR TITLE
only run css style lint in src path (#336)

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -463,6 +463,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 							'to not contain universal (*) selectors due to unsafe isolation'
 						);
 				},
+				context: srcPath,
 				files: ['**/*.m.css']
 			}),
 			singleBundle &&


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

backport of #336 
