### PR TITLE
Remove erroneous single bundle check on DefinePlugin

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -486,11 +486,10 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					cldrPaths: args.cldrPaths,
 					target: mainEntryPath
 				}),
-			!singleBundle &&
-				new webpack.DefinePlugin({
-					__MAIN_ENTRY: JSON.stringify(mainEntryPath),
-					__DOJO_SCOPE: `'${libraryName}'`
-				}),
+			new webpack.DefinePlugin({
+				__MAIN_ENTRY: JSON.stringify(mainEntryPath),
+				__DOJO_SCOPE: `'${libraryName}'`
+			}),
 			!isExperimentalSpeed &&
 				new OptimizeCssAssetsPlugin({
 					cssProcessor: cssnano,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)

**Description:**
Removes erroneous single bundle guard on the DefinePlugin. It can be safely used in any mode.

Apologies for patch branch, this was authored on mobile.

Resolves #338 
