### PR TITLE
Adding glob for spec files as unit tests

### DIFF
--- a/src/unit.config.ts
+++ b/src/unit.config.ts
@@ -12,7 +12,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	const outputPath = output!.path as string;
 	config.entry = () => {
 		const unit = globby
-			.sync([`${basePath}/tests/unit/**/*.ts`])
+			.sync([`${basePath}/tests/unit/**/*.ts`, `${basePath}/src/**/*.spec.{ts,tsx}`])
 			.map((filename: string) => filename.replace(/\.ts$/, ''));
 
 		const tests: any = {};

--- a/src/unit.config.ts
+++ b/src/unit.config.ts
@@ -12,7 +12,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	const outputPath = output!.path as string;
 	config.entry = () => {
 		const unit = globby
-			.sync([`${basePath}/tests/unit/**/*.ts`, `${basePath}/src/**/*.spec.{ts,tsx}`])
+			.sync([`${basePath}/tests/unit/**/*.{ts,tsx}`, `${basePath}/src/**/*.spec.{ts,tsx}`])
 			.map((filename: string) => filename.replace(/\.ts$/, ''));
 
 		const tests: any = {};

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -13,7 +13,7 @@
     "build:dev:pwa": "dojo build --dojorc .dojorc-dev-pwa",
     "build:dist:pwa:evergreen": "dojo build --dojorc .dojorc-dist-pwa-evergreen",
     "build:dev:pwa:evergreen": "dojo build --dojorc .dojorc-dev-pwa-evergreen",
-    "build:test": "dojo build --mode test"
+    "build:test": "dojo build --mode unit"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding a glob to discover `.spec.ts` and `.spec.tsx` files in the source directory and include them in unit test builds.

There are currently not tests for test builds, so I didn't _add_ anything, but I manually tested this by adding a `test.spec.ts` in the `test-app/src` directory and did a unit test build. I then manually verified that the test was included in the built bundle.

Resolves #341 
