### PR TITLE
Excluding spec files from coverage

### DIFF
--- a/src/base.test.config.ts
+++ b/src/base.test.config.ts
@@ -51,6 +51,7 @@ function webpackConfig(args: any): webpack.Configuration {
 				loader: 'istanbul-instrumenter-loader',
 				options: instrumenterOptions
 			},
+			exclude: /\.spec\.ts(x)?$/,
 			enforce: 'post'
 		});
 	}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Excluding `.spec.ts` and `.spec.tsx` files from being instrumented by istanbul.
