### PR TITLE
Prefix library to avoid clashes on the global scope

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -383,7 +383,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		},
 		output: {
 			chunkFilename: '[name].js',
-			library: libraryName,
+			library: `lib_${libraryName}`,
 			umdNamedDefine: true,
 			filename: '[name].js',
 			jsonpFunction: `dojoWebpackJsonp${libraryName}`,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR
* [x] schema.json has been updated appopriately

**Description:**

Prefix library name to avoid clashes on the global scope.

Resolves #347 
