### PR TITLE
Correct watching section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,14 +190,14 @@ Note: Setting the proxy configuration as a string is equivelant to `{ target: "s
 
 ### Watching
 
-Building with the `--watch` option observes the file system for changes, and recompiles to the appropriate `output/{dist|dev|test}` directory, depending on the current `--mode`. When used in the conjunction with the `--serve` option and `--mode=dev`, `--watch=memory` can be specified to enable automatic browser updates and hot module replacement (HMR).
+Building with the `--watch` option observes the file system for changes and when with the development server (`--serve`) will automatically reload you browser.
 
 ```bash
-# start a file-based watch
-dojo build -w
+# start a build with watch
+dojo build --mode=dev --watch
 
-# build to an in-memory file system with HMR
-dojo build -s -w=memory -m=dev
+# start a build using the development server and live reload
+dojo build --mode=dev --serve --watch
 ```
 
 ### Eject


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

**Description:**

The `watch` no longer takes a `file` or `memory` option