### PR TITLE
On-demand build time render for when using watch with the development server

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "sinon": "~4.5.0"
   },
   "dependencies": {
-    "@dojo/webpack-contrib": "7.0.0-alpha.6",
+    "@dojo/webpack-contrib": "7.0.0-alpha.8",
     "brotli-webpack-plugin": "1.0.0",
     "caniuse-lite": "1.0.30000973",
     "chalk": "2.4.1",

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -119,15 +119,17 @@ window['${libraryName}'].base = '${base}'</script>`,
 		});
 	}
 
+	const btrOptions = args['build-time-render'] || {};
 	if (args['build-time-render']) {
 		config.plugins.push(
 			new BuildTimeRender({
-				...args['build-time-render'],
+				...btrOptions,
 				sync: singleBundle,
 				entries: Object.keys(config.entry!),
 				basePath,
 				baseUrl: base,
-				scope: libraryName
+				scope: libraryName,
+				watch: Boolean(args.watch && args.serve && btrOptions.static)
 			})
 		);
 	}

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -13,7 +13,7 @@ import ServiceWorkerPlugin, {
 import * as fs from 'fs';
 import * as path from 'path';
 import webpack = require('webpack');
-import BuildTimeRender from '@dojo/webpack-contrib/build-time-render/BuildTimeRender';
+import BuildTimeRender, { BuildTimeRenderArguments } from '@dojo/webpack-contrib/build-time-render/BuildTimeRender';
 import ExternalLoaderPlugin from '@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin';
 import * as CleanWebpackPlugin from 'clean-webpack-plugin';
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
@@ -119,8 +119,20 @@ window['${libraryName}'].base = '${base}'</script>`,
 		});
 	}
 
-	const btrOptions = args['build-time-render'] || {};
+	const btrOptions: BuildTimeRenderArguments = args['build-time-render'];
 	if (args['build-time-render']) {
+		const paths = btrOptions.paths || [];
+		let isStatic = btrOptions.static;
+		if (isStatic === true) {
+			for (let i = 0; i < paths.length; i++) {
+				const path = paths[i];
+				if (typeof path === 'object' && path.static === false) {
+					isStatic = false;
+					break;
+				}
+			}
+		}
+		
 		config.plugins.push(
 			new BuildTimeRender({
 				...btrOptions,
@@ -129,7 +141,7 @@ window['${libraryName}'].base = '${base}'</script>`,
 				basePath,
 				baseUrl: base,
 				scope: libraryName,
-				watch: Boolean(args.watch && args.serve && btrOptions.static)
+				watch: Boolean(args.watch && args.serve && isStatic)
 			})
 		);
 	}

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -1,4 +1,4 @@
-import BuildTimeRender from '@dojo/webpack-contrib/build-time-render/BuildTimeRender';
+import BuildTimeRender, { BuildTimeRenderArguments } from '@dojo/webpack-contrib/build-time-render/BuildTimeRender';
 import ExternalLoaderPlugin from '@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin';
 import BundleAnalyzerPlugin from '@dojo/webpack-contrib/webpack-bundle-analyzer/BundleAnalyzerPlugin';
 import ServiceWorkerPlugin, {
@@ -122,8 +122,19 @@ function webpackConfig(args: any): webpack.Configuration {
 		new CleanWebpackPlugin(['dist', 'info'], { root: output!.path, verbose: false })
 	].filter((item) => item);
 
-	const btrOptions = args['build-time-render'] || {};
+	const btrOptions: BuildTimeRenderArguments = args['build-time-render'];
 	if (args['build-time-render']) {
+		const paths = btrOptions.paths || [];
+		let isStatic = btrOptions.static;
+		if (isStatic === true) {
+			for (let i = 0; i < paths.length; i++) {
+				const path = paths[i];
+				if (typeof path === 'object' && path.static === false) {
+					isStatic = false;
+					break;
+				}
+			}
+		}
 		config.plugins.push(
 			new BuildTimeRender({
 				...btrOptions,

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -122,15 +122,17 @@ function webpackConfig(args: any): webpack.Configuration {
 		new CleanWebpackPlugin(['dist', 'info'], { root: output!.path, verbose: false })
 	].filter((item) => item);
 
+	const btrOptions = args['build-time-render'] || {};
 	if (args['build-time-render']) {
 		config.plugins.push(
 			new BuildTimeRender({
-				...args['build-time-render'],
+				...btrOptions,
 				entries: Object.keys(config.entry!),
 				sync: args.singleBundle,
 				basePath,
 				baseUrl: base,
-				scope: libraryName
+				scope: libraryName,
+				watch: Boolean(args.watch && args.serve && btrOptions.static)
 			})
 		);
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR
* [x] schema.json has been updated appropriately

**Description:**

Adds an express middleware that runs build time rendering (if the application is configured for btr in the `.dojorc`) for the requested page on-demand. This means that the full build time rendering process does not have to be executed every time a project re-builds. Once BTR has been executed it will not run again until the watch build has re-run. 

**Note:** Currently only available for full static applications as when applications load javascript the routing system does not make the required requests to the server.

Related to #367 

**Note:** requires release of webpack-contrib
