### PR TITLE
Added tsx to list of linted file extensions

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -557,7 +557,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				},
 				tsLint && {
 					include: allPaths,
-					test: /\.ts$/,
+					test: /\.(ts|tsx)$/,
 					enforce: 'pre',
 					loader: 'tslint-loader',
 					options: { configuration: tsLint, emitErrors: true, failOnHint: true }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updated the webpack config in base.config to include tsx as a file extension for the tslint-loader. Tested manually.

Resolves #351 

![image](https://user-images.githubusercontent.com/331431/73496700-6b159580-4376-11ea-9a5f-e06b1fd9b8da.png)

