### PR TITLE
Remove css rule for dts loader

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -576,16 +576,6 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				},
 				{
 					include: allPaths,
-					test: /\.m\.css$/,
-					enforce: 'pre',
-					loader: '@dojo/webpack-contrib/css-module-dts-loader?type=css',
-					options: {
-						type: 'css',
-						sourceFilesPattern: new RegExp('src[\\/].*.m.css$')
-					}
-				},
-				{
-					include: allPaths,
 					test: /\.ts(x)?$/,
 					use: removeEmpty([
 						features && {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This is related to #369 but doesn't fix it by itself. This rule was making the dts loader process files it never should have, and therefore resulted in a bug where dts files were being generated for inappropriate files. By removing this rule we can fix the issue properly in webpack-contrib by simply ignoring non-relative imports in TS files.
