### PR TITLE
Notify to not use `--serve` in production

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -218,6 +218,10 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 		isHttps = true;
 	}
 
+	if (testModes.indexOf(args.mode) === -1 || process.env.NODE_ENV === 'production') {
+		console.warn('The serve option is not intended to be used to serve applications in production.');
+	}
+
 	return Promise.resolve()
 		.then(() => {
 			if (args.watch) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,11 @@ function fileWatch(config: webpack.Configuration, args: any, app?: express.Appli
 				reject(err);
 			}
 			if (stats) {
-				const runningMessage = args.serve ? `Listening on port ${args.port}` : 'watching...';
+				const runningMessage = args.serve
+					? `Listening on port ${
+							args.port
+					  }\nPlease note the serve option is not intended to be used to serve applications in production.`
+					: 'watching...';
 				logger(stats.toJson({ warningsFilter }), config, runningMessage, args);
 			}
 			resolve();
@@ -216,10 +220,6 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 
 	if (fs.existsSync(defaultKey) && fs.existsSync(defaultCrt)) {
 		isHttps = true;
-	}
-
-	if (testModes.indexOf(args.mode) === -1 || process.env.NODE_ENV === 'production') {
-		console.warn('The serve option is not intended to be used to serve applications in production.');
 	}
 
 	return Promise.resolve()


### PR DESCRIPTION
**Type:**  feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Displays a warning during `--serve` to not use the server in production

Resolves #296 

![image](https://user-images.githubusercontent.com/331431/73870630-a9450600-4809-11ea-9389-51036beca9f2.png)


