### PR TITLE
add support to tslint.json linterOptions.exclude

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -12,6 +12,7 @@ import * as webpack from 'webpack';
 import * as cssnano from 'cssnano';
 import * as minimatch from 'minimatch';
 import * as ManifestPlugin from 'webpack-manifest-plugin';
+import * as globby from 'globby';
 
 const postcssPresetEnv = require('postcss-preset-env');
 const postcssImport = require('postcss-import');
@@ -44,6 +45,12 @@ export const packageName = packageJson.name || '';
 
 const tsLintPath = path.join(basePath, 'tslint.json');
 const tsLint = existsSync(tsLintPath) ? require(tsLintPath) : false;
+const tsLintExcludes =
+	(tsLint &&
+		tsLint.linterOptions &&
+		tsLint.linterOptions.exclude &&
+		globby.sync(tsLint.linterOptions.exclude).map((file) => path.resolve(file))) ||
+	[];
 
 function getLibraryName(name: string) {
 	return name
@@ -560,7 +567,8 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					test: /\.(ts|tsx)$/,
 					enforce: 'pre',
 					loader: 'tslint-loader',
-					options: { configuration: tsLint, emitErrors: true, failOnHint: true }
+					options: { configuration: tsLint, emitErrors: true, failOnHint: true },
+					exclude: tsLintExcludes
 				},
 				{
 					test: /@dojo(\/|\\).*\.(js|mjs)$/,

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -45,12 +45,13 @@ export const packageName = packageJson.name || '';
 
 const tsLintPath = path.join(basePath, 'tslint.json');
 const tsLint = existsSync(tsLintPath) ? require(tsLintPath) : false;
-const tsLintExcludes =
-	(tsLint &&
-		tsLint.linterOptions &&
-		tsLint.linterOptions.exclude &&
-		globby.sync(tsLint.linterOptions.exclude).map((file) => path.resolve(file))) ||
-	[];
+
+function getTsLintExclusions() {
+	if (tsLint && tsLint.linterOptions && tsLint.linterOptions.exclude) {
+		return globby.sync(tsLint.linterOptions.exclude).map((file) => path.resolve(file));
+	}
+	return [];
+}
 
 function getLibraryName(name: string) {
 	return name
@@ -568,7 +569,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					enforce: 'pre',
 					loader: 'tslint-loader',
 					options: { configuration: tsLint, emitErrors: true, failOnHint: true },
-					exclude: tsLintExcludes
+					exclude: getTsLintExclusions()
 				},
 				{
 					test: /@dojo(\/|\\).*\.(js|mjs)$/,

--- a/test-app/src/main.ts
+++ b/test-app/src/main.ts
@@ -5,6 +5,7 @@ import { registerRouterInjector } from '@dojo/framework/routing/RouterInjector';
 import App from './App';
 import * as css from './app.m.css';
 import './Bar';
+import './tslintTest';
 import LazyApp from './LazyApp';
 import routes from './routes';
 import test from './test.block';

--- a/test-app/src/tslintTest.ts
+++ b/test-app/src/tslintTest.ts
@@ -1,0 +1,2 @@
+// This would fail linting without `exclude` support from @dojo/cli-build-app
+export var thisWouldFailLinting: any;

--- a/test-app/tslint.json
+++ b/test-app/tslint.json
@@ -1,0 +1,40 @@
+{
+	"rules": {
+		"align": false,
+		"ban": [],
+		"class-name": true,
+		"comment-format": [ true, "check-space" ],
+		"curly": true,
+		"forin": false,
+		"interface-name": [ true, "never-prefix" ],
+		"jsdoc-format": true,
+		"label-position": true,
+		"member-access": false,
+		"member-ordering": false,
+		"no-any": false,
+		"no-arg": true,
+		"no-bitwise": false,
+		"no-console": false,
+		"no-construct": false,
+		"no-debugger": true,
+		"no-duplicate-variable": true,
+		"no-empty": false,
+		"no-eval": true,
+		"no-inferrable-types": [ true, "ignore-params" ],
+		"no-shadowed-variable": false,
+		"no-string-literal": false,
+		"no-switch-case-fall-through": false,
+		"no-unused-expression": false,
+		"no-use-before-declare": false,
+		"no-var-keyword": true,
+		"no-var-requires": false,
+		"object-literal-sort-keys": false,
+		"radix": true,
+		"triple-equals": [ true, "allow-null-check" ],
+		"typedef": false,
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ]
+	},
+	"linterOptions": {
+		"exclude": [ "**/tslint*.ts" ]
+	}
+}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This adds support to dojo's tslint-loader configuration to support tslint's `linterOptions.exclude`.

It turns out that tslint-loader doesn't support this (https://github.com/wbuchwalter/tslint-loader/issues/104). So to implement this we're using webpack's `exclude` option to explicitly avoid linting files in the tslint.json exclude and using `globby` to generate a list of absolute paths to files to exclude.

Resolves #85
