### PR TITLE
theme variants: Remove variables import

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -278,27 +278,6 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		}
 	};
 
-	const postcssImportConfig = {
-		filter: (path: string) => {
-			return /.*variables(\.m)?\.css$/.test(path);
-		},
-		load: (filename: string, importOptions: any = {}) => {
-			return readFileSync(filename, 'utf8').replace('color(', 'color-mod(');
-		},
-		resolve: (id: string, basedir: string, importOptions: any = {}) => {
-			if (importOptions.filter) {
-				const result = importOptions.filter(id);
-				if (!result) {
-					return null;
-				}
-			}
-			if (id[0] === '~') {
-				return id.substr(1);
-			}
-			return id;
-		}
-	};
-
 	const postcssPresetConfig = {
 		browsers: isLegacy ? ['last 2 versions', 'ie >= 10'] : ['last 2 versions'],
 		insertBefore: {
@@ -343,14 +322,14 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 			loader: 'postcss-loader?sourceMap',
 			options: {
 				ident: 'postcss',
-				plugins: [postcssImport(postcssImportConfig), postcssPresetEnv(postcssPresetConfig)]
+				plugins: [postcssPresetEnv(postcssPresetConfig)]
 			}
 		});
 		cssLoader.push({
 			loader: 'postcss-loader?sourceMap',
 			options: {
 				ident: 'postcss',
-				plugins: [postcssImport(postcssImportConfig), postcssPresetEnv(postcssPresetConfig)]
+				plugins: [postcssPresetEnv(postcssPresetConfig)]
 			}
 		});
 	}

--- a/tests/integration/build.spec.ts
+++ b/tests/integration/build.spec.ts
@@ -60,27 +60,6 @@ Currently Rendered by BTR: false`
 		});
 	});
 
-	describe('css variables', () => {
-		it('correctly inlines and resolves external variables for legacy builds', () => {
-			cy.request('/test-app/output/dev-app/main.css').then((response) => {
-				const css = response.body;
-				expect(css).to.contain('color:var(--foreground-color);');
-				expect(css).to.contain('color:#00f;');
-				expect(css).to.contain('color:var(--primary);');
-				expect(css).to.contain('color:red;');
-			});
-		});
-		it('correctly inlines and resolves external variables for evergreen builds', () => {
-			cy.request('/test-app/output/dev-app-evergreen/main.css').then((response) => {
-				const css = response.body;
-				expect(css).to.contain('color:var(--foreground-color);');
-				expect(css).to.contain('color:#00f;');
-				expect(css).to.contain('color:var(--primary);');
-				expect(css).to.contain('color:red;');
-			});
-		});
-	});
-
 	describe('static only features', () => {
 		it('ignores add calls for static only features', () => {
 			cy.request('/test-app/output/dev-app-evergreen/bootstrap.js').then((response) => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removes special rules for importing `variables.css` files. These will now be used as theme variants.

work towards: https://github.com/dojo/framework/issues/683
