### PR TITLE
Remove ".bundle." from filenames

### DIFF
--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -138,7 +138,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	config.plugins = config.plugins.map((plugin) => {
 		if (plugin instanceof MiniCssExtractPlugin) {
 			return new MiniCssExtractPlugin({
-				filename: args.omitHash ? '[name].bundle.css' : '[name].[contenthash].bundle.css'
+				filename: args.omitHash ? '[name].css' : '[name].[contenthash].css'
 			});
 		}
 		return plugin;
@@ -159,8 +159,8 @@ function webpackConfig(args: any): webpack.Configuration {
 	config.output = {
 		...output,
 		path: outputPath,
-		chunkFilename: args.omitHash ? '[name].bundle.js' : '[name].[chunkhash].bundle.js',
-		filename: args.omitHash ? '[name].bundle.js' : '[name].[chunkhash].bundle.js'
+		chunkFilename: args.omitHash ? '[name].js' : '[name].[chunkhash].js',
+		filename: args.omitHash ? '[name].js' : '[name].[chunkhash].js'
 	};
 
 	return config;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This simply removes `.bundle.` from all dist bundle files. The inclusion of `bundle` in the filename makes it more difficult to pull in `main.js` in both the dist and dev builds from an external file (used by parade to run tests in the browser). Unless there's a reason this was done in the first place removing the `.bundle.` would make supporting that much easier.
