### PR TITLE
Include css var polyfill for legacy builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8108,6 +8108,11 @@
         "loader-utils": "^1.1.0"
       }
     },
+    "ie11-custom-properties": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/ie11-custom-properties/-/ie11-custom-properties-3.0.6.tgz",
+      "integrity": "sha512-IIyVr9NhUc1LNwxEO9hlfE2Tw7X/dKzuIAXMB+FyJaN18WXxN9yJ3uE+se60nFcjRSfNgntyGuosh4daxaXpsA=="
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "html-webpack-plugin": "3.2.0",
     "http-proxy-middleware": "^0.19.0",
     "identity-loader": "1.0.1",
+    "ie11-custom-properties": "3.0.6",
     "imports-loader": "0.8.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "json-css-module-loader": "1.0.2",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -228,6 +228,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	if (singleBundle) {
 		entry = {
 			[mainEntry]: removeEmpty([
+				isLegacy && 'ie11-custom-properties',
 				'@dojo/framework/shim/Promise',
 				'@dojo/webpack-contrib/bootstrap-plugin/sync',
 				existsSync(mainCssPath) ? mainCssPath : null,
@@ -239,6 +240,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		staticOnly.push('build-elide');
 		entry = {
 			[bootstrapEntry]: removeEmpty([
+				isLegacy && 'ie11-custom-properties',
 				existsSync(mainCssPath) ? mainCssPath : null,
 				'@dojo/framework/shim/Promise',
 				'@dojo/webpack-contrib/bootstrap-plugin/async'


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR
* [x] schema.json has been updated appropriately

**Description:**

Include the css var polyfill for legacy builds.

Related to https://github.com/dojo/framework/issues/683