### PR TITLE
Support for On Demand BTR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -895,9 +895,9 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "7.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-beta.1.tgz",
-      "integrity": "sha512-2u+pWB9wM5kxYsqsJRLRJZyxvKN7QJdvPFXhVgGFoV2FkH303w16NuaqH2XV8gsqXN9Fg0EmJRacDsNxFY8IuA==",
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-beta.2.tgz",
+      "integrity": "sha512-hzU4V37sP9Ip3qnI/w9cGQfwMkAuDpAaVowoAQ7Z0fZhK6mFMenYmEiyER5n19c04dkHfwT5tavO7MkE1Nw8rw==",
       "requires": {
         "@dojo/framework": "7.0.0-beta.1",
         "acorn": "6.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,11 +66,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
-      "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+      "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
       "requires": {
-        "@babel/types": "^7.9.0",
+        "@babel/types": "^7.9.5",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -94,13 +94,13 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+      "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
       "requires": {
         "@babel/helper-get-function-arity": "^7.8.3",
         "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.9.5"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -185,9 +185,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
-      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw=="
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
     },
     "@babel/helpers": {
       "version": "7.9.2",
@@ -232,16 +232,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
-      "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+      "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.0",
-        "@babel/helper-function-name": "^7.8.3",
+        "@babel/generator": "^7.9.5",
+        "@babel/helper-function-name": "^7.9.5",
         "@babel/helper-split-export-declaration": "^7.8.3",
         "@babel/parser": "^7.9.0",
-        "@babel/types": "^7.9.0",
+        "@babel/types": "^7.9.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -260,11 +260,11 @@
       }
     },
     "@babel/types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-      "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+      "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
+        "@babel/helper-validator-identifier": "^7.9.5",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       },
@@ -734,9 +734,9 @@
       }
     },
     "@dojo/framework": {
-      "version": "7.0.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.16.tgz",
-      "integrity": "sha512-dgzJmQPD90WWDmrzNRc0EagdOTlm5x8bS27wsbVMAL00YXd6vYv658Rh3SX9yjutFfy+M240aE6kSSkAqCJZaA==",
+      "version": "7.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-beta.1.tgz",
+      "integrity": "sha512-nGHc2ryeze0JgSVILr4oqJbUyfVv/DdKzC/UFy31OfrK6E/0fGQAawIylyVgr+APIlozzy92N/6/KC/SLV8cWg==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
@@ -895,11 +895,11 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "7.0.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.15.tgz",
-      "integrity": "sha512-ErtEw4jB+8orIyQ4xYzp2sFvStz8g9CdxmbU5l9wQAkpSvrp1bMVUbbCZNPnv1A5OCmAgTyiUsDClF+MnGpo+A==",
+      "version": "7.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-beta.1.tgz",
+      "integrity": "sha512-2u+pWB9wM5kxYsqsJRLRJZyxvKN7QJdvPFXhVgGFoV2FkH303w16NuaqH2XV8gsqXN9Fg0EmJRacDsNxFY8IuA==",
       "requires": {
-        "@dojo/framework": "7.0.0-alpha.16",
+        "@dojo/framework": "7.0.0-beta.1",
         "acorn": "6.1.1",
         "acorn-dynamic-import": "4.0.0",
         "acorn-walk": "6.1.1",
@@ -1013,9 +1013,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.9.0.tgz",
-      "integrity": "sha512-OBIKtF6ttIJotDXe4KJMUyTBO4xMii+mFjlA8R4CORuD4HvCUaCK3lPjhdTRCvuEv6gzWNbAvd9DNBv0v780lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.10.0.tgz",
+      "integrity": "sha512-hlueNXU51c3CwQjBw/i5fwt+VfQgSQVUTdicpCHkhEjNZaa4CXJ5W1GaxSwtLE2dvRmAHjpIjUMHTqJ53uojfg==",
       "requires": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -1097,9 +1097,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@sinonjs/commons": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
-      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -1379,9 +1379,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.11.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.0.tgz",
-          "integrity": "sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ=="
+          "version": "13.11.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
+          "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
         }
       }
     },
@@ -1672,9 +1672,9 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.5.tgz",
-      "integrity": "sha512-L7EbSkhSaWBpkl+PZAEAqZTqtTeIsq7s/oX/q0LNnxxJoRVKQE0T81XDVyaxjiiKQwiV2vhVeYRqxdRNqGOGJw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.0.tgz",
+      "integrity": "sha512-3ZcoyPYHVOCcLpnfZwD47KFLr8W/mpUcgjpf1M4Q78TMJIw7KMAHSjiCLJp1z3ZrBR9pTLbe191O0TldFK5zcw==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -1696,9 +1696,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.11.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.0.tgz",
-          "integrity": "sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ=="
+          "version": "13.11.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
+          "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
         }
       }
     },
@@ -2319,9 +2319,9 @@
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001039",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
-          "integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
+          "version": "1.0.30001042",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
+          "integrity": "sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -2963,16 +2963,16 @@
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001039",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
-          "integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
+          "version": "1.0.30001042",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
+          "integrity": "sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw=="
         }
       }
     },
     "buffer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-      "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -3522,9 +3522,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "clipboardy": {
@@ -3650,9 +3650,9 @@
       }
     },
     "command-exists": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-      "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
       "dev": true
     },
     "commander": {
@@ -4033,9 +4033,9 @@
       }
     },
     "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
       "optional": true
     },
     "core-util-is": {
@@ -5754,16 +5754,16 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.34",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
-          "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g=="
+          "version": "12.12.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.35.tgz",
+          "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ=="
         }
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.398",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.398.tgz",
-      "integrity": "sha512-BJjxuWLKFbM5axH3vES7HKMQgAknq9PZHBkMK/rEXUQG9i1Iw5R+6hGkm6GtsQSANjSUrh/a6m32nzCNDNo/+w=="
+      "version": "1.3.412",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.412.tgz",
+      "integrity": "sha512-4bVdSeJScR8fT7ERveLWbxemY5uXEHVseqMRyORosiKcTUSGtVwBkV8uLjXCqoFLeImA57Z9hbz3TOid01U4Hw=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -7906,9 +7906,9 @@
       }
     },
     "html-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
+      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
     },
     "html-loader": {
       "version": "0.5.5",
@@ -13306,9 +13306,9 @@
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001039",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
-          "integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
+          "version": "1.0.30001042",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
+          "integrity": "sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -14408,9 +14408,9 @@
       "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.0.tgz",
+      "integrity": "sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -14617,9 +14617,9 @@
       }
     },
     "semver": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.1.tgz",
-      "integrity": "sha512-aHhm1pD02jXXkyIpq25qBZjr3CQgg8KST8uX0OWXch3xE6jw+1bfbWnCjzMwojsTquroUmKFHNzU6x26mEiRxw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
       "optional": true
     },
     "semver-compare": {
@@ -15517,9 +15517,9 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
-      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -15546,9 +15546,9 @@
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
-      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -17029,9 +17029,9 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.0.tgz",
-      "integrity": "sha512-kVx7CDAsdBSWVf404Mw7oI9i09w5/mTT/Ruk+RWa64PLYKvsAucLLFHvQtnvjeADM4ZizxrvG5SHnF4Te4T2Cg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.1.tgz",
+      "integrity": "sha512-sgDYfSDPMsA4Hr2/w7vOlrJBlwzmyakk1+hW8ObLvxSp0LA36LcL2XItGvOT3OSblohSdevMuT8FQjLsqyy4sA==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "sinon": "~4.5.0"
   },
   "dependencies": {
-    "@dojo/webpack-contrib": "7.0.0-beta.1",
+    "@dojo/webpack-contrib": "7.0.0-beta.2",
     "brotli-webpack-plugin": "1.0.0",
     "caniuse-lite": "1.0.30000973",
     "chalk": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "sinon": "~4.5.0"
   },
   "dependencies": {
-    "@dojo/webpack-contrib": "7.0.0-alpha.15",
+    "@dojo/webpack-contrib": "7.0.0-beta.1",
     "brotli-webpack-plugin": "1.0.0",
     "caniuse-lite": "1.0.30000973",
     "chalk": "2.4.1",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -209,7 +209,12 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 	const extensions = isLegacy ? ['.ts', '.tsx', '.js'] : ['.ts', '.tsx', '.mjs', '.js'];
 	const compilerOptions = isLegacy ? {} : { target: 'es2017', module: 'esnext', downlevelIteration: false };
 	let features = isLegacy ? args.features : { ...(args.features || {}), ...getFeatures('modern') };
-	features = { ...features, 'dojo-debug': false, 'cldr-elide': true };
+	features = {
+		...features,
+		'dojo-debug': false,
+		'cldr-elide': true,
+		'build-time-rendered': !!args['build-time-render']
+	};
 	const staticOnly = [];
 	const assetsDir = path.join(process.cwd(), 'assets');
 	const assetsDirPattern = new RegExp(assetsDir);

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -127,7 +127,8 @@ window['${libraryName}'].base = '${base}'</script>`,
 				entries: Object.keys(config.entry!),
 				basePath,
 				baseUrl: base,
-				scope: libraryName
+				scope: libraryName,
+				onDemand: Boolean(args.serve && args.watch)
 			})
 		);
 	}

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -130,7 +130,8 @@ function webpackConfig(args: any): webpack.Configuration {
 				sync: args.singleBundle,
 				basePath,
 				baseUrl: base,
-				scope: libraryName
+				scope: libraryName,
+				onDemand: Boolean(args.serve && args.watch)
 			})
 		);
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import * as https from 'https';
 import * as expressCompression from 'compression';
 import * as proxy from 'http-proxy-middleware';
 import * as history from 'connect-history-api-fallback';
+import OnDemandBtr from '@dojo/webpack-contrib/build-time-render/BuildTimeRenderMiddleware';
 
 const pkgDir = require('pkg-dir');
 const expressStaticGzip = require('express-static-gzip');
@@ -21,6 +22,20 @@ import distConfigFactory from './dist.config';
 import logger from './logger';
 import { moveBuildOptions } from './util/eject';
 import { readFileSync } from 'fs';
+
+export const mainEntry = 'main';
+const packageJsonPath = path.join(process.cwd(), 'package.json');
+const packageJson = fs.existsSync(packageJsonPath) ? require(packageJsonPath) : {};
+export const packageName = packageJson.name || '';
+
+function getLibraryName(name: string) {
+	return name
+		.replace(/[^a-z0-9_]/g, ' ')
+		.trim()
+		.replace(/\s+/g, '_');
+}
+
+const libraryName = packageName ? getLibraryName(packageName) : 'main';
 
 const fixMultipleWatchTrigger = require('webpack-mild-compile');
 const hotMiddleware = require('webpack-hot-middleware');
@@ -71,7 +86,7 @@ function serveStatic(
 function build(config: webpack.Configuration, args: any) {
 	const compiler = createCompiler(config);
 	const spinner = ora('building').start();
-	return new Promise<void>((resolve, reject) => {
+	return new Promise<webpack.Compiler>((resolve, reject) => {
 		compiler.run((err, stats) => {
 			spinner.stop();
 			if (err) {
@@ -90,7 +105,7 @@ function build(config: webpack.Configuration, args: any) {
 					'Using `--mode=test` is deprecated and has only built the unit test bundle. This mode will be removed in the next major release, please use `unit` or `functional` explicitly instead.'
 				);
 			}
-			resolve(args.serve);
+			resolve(compiler);
 		});
 	});
 }
@@ -110,19 +125,10 @@ function buildNpmDependencies(): any {
 	}
 }
 
-function fileWatch(config: webpack.Configuration, args: any, app?: express.Application): Promise<void> {
-	let compiler: webpack.Compiler;
-	const base = args.base || '/';
-	if (args.serve && app) {
-		const timeout = 20 * 1000;
-		compiler = createWatchCompiler(config);
-		app.use(base, hotMiddleware(compiler, { heartbeat: timeout / 2 }));
-	} else {
-		compiler = createWatchCompiler(config);
-	}
-
-	return new Promise<void>((resolve, reject) => {
+async function fileWatch(config: webpack.Configuration, args: any) {
+	return new Promise<webpack.Compiler>((resolve, reject) => {
 		const watchOptions = config.watchOptions as webpack.Compiler.WatchOptions;
+		const compiler = createWatchCompiler(config);
 		compiler.watch(watchOptions, (err, stats) => {
 			if (err) {
 				reject(err);
@@ -135,17 +141,18 @@ function fileWatch(config: webpack.Configuration, args: any, app?: express.Appli
 					: 'watching...';
 				logger(stats.toJson({ warningsFilter }), config, runningMessage, args);
 			}
-			resolve();
+			resolve(compiler);
 		});
 	});
 }
 
-function serve(config: webpack.Configuration, args: any): Promise<void> {
+async function serve(config: webpack.Configuration, args: any) {
+	const compiler = args.watch ? await fileWatch(config, args) : await build(config, args);
 	let isHttps = false;
 	const base = args.base || '/';
 
 	const app = express();
-	app.use(base, function(req, res, next) {
+	app.use(base, function(req, _, next) {
 		const { pathname } = url.parse(req.url);
 		if (req.accepts('html') && pathname && !pathname.match(/\..*$/)) {
 			req.url = `${req.url}/`;
@@ -154,6 +161,21 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 	});
 
 	const outputDir = (config.output && config.output.path) || process.cwd();
+	const brtOptions = args['build-time-render'];
+	if (brtOptions) {
+		const jsonpName = (config.output && config.output.jsonpFunction) || 'unknown';
+		const onDemandBtr = new OnDemandBtr({
+			buildTimeRenderOptions: brtOptions,
+			scope: libraryName,
+			base,
+			compiler,
+			entries: config.entry ? Object.keys(config.entry) : [],
+			outputPath: outputDir,
+			jsonpName
+		});
+		app.use(base, onDemandBtr.middleware);
+	}
+
 	if (args.mode !== 'dist' || !Array.isArray(args.compression)) {
 		app.use(base, expressCompression());
 	}
@@ -222,43 +244,38 @@ function serve(config: webpack.Configuration, args: any): Promise<void> {
 		isHttps = true;
 	}
 
-	return Promise.resolve()
-		.then(() => {
-			if (args.watch) {
-				return fileWatch(config, args, app);
-			}
+	if (args.watch) {
+		const timeout = 20 * 1000;
+		app.use(base, hotMiddleware(compiler, { heartbeat: timeout / 2 }));
+	}
 
-			return build(config, args);
-		})
-		.then(() => {
-			return new Promise<void>((resolve, reject) => {
-				if (isHttps) {
-					https
-						.createServer(
-							{
-								key: fs.readFileSync(defaultKey),
-								cert: fs.readFileSync(defaultCrt)
-							},
-							app
-						)
-						.listen(args.port, (error: Error) => {
-							if (error) {
-								reject(error);
-							} else {
-								resolve();
-							}
-						});
+	return new Promise<void>((resolve, reject) => {
+		if (isHttps) {
+			https
+				.createServer(
+					{
+						key: fs.readFileSync(defaultKey),
+						cert: fs.readFileSync(defaultCrt)
+					},
+					app
+				)
+				.listen(args.port, (error: Error) => {
+					if (error) {
+						reject(error);
+					} else {
+						resolve();
+					}
+				});
+		} else {
+			app.listen(args.port, (error: Error) => {
+				if (error) {
+					reject(error);
 				} else {
-					app.listen(args.port, (error: Error) => {
-						if (error) {
-							reject(error);
-						} else {
-							resolve();
-						}
-					});
+					resolve();
 				}
 			});
-		});
+		}
+	});
 }
 
 function warningsFilter(warning: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,7 +173,7 @@ async function serve(config: webpack.Configuration, args: any) {
 			outputPath: outputDir,
 			jsonpName
 		});
-		app.use(base, onDemandBtr.middleware);
+		app.use(base, (req, res, next) => onDemandBtr.middleware(req, res, next));
 	}
 
 	if (args.mode !== 'dist' || !Array.isArray(args.compression)) {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -66,7 +66,8 @@ describe('command', () => {
 			'webpack',
 			'webpack-dev-middleware',
 			'webpack-hot-middleware',
-			'webpack-mild-compile'
+			'webpack-mild-compile',
+			'@dojo/webpack-contrib/build-time-render/BuildTimeRenderMiddleware'
 		]);
 		invalidHookStub = stub().callsFake((name: string, callback: Function) => callback());
 		doneHookStub = stub().callsFake((name: string, callback: Function) => callback(stats));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR
* [x] schema.json has been updated appropriately

**Description:**

Uses the on demand BTR middleware from webpack-contrib and turns the mode on when using btr in build and watch.

Resolves #367 
