### PR TITLE
support on demand btr in sync mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -161,11 +161,14 @@ async function serve(config: webpack.Configuration, args: any) {
 	});
 
 	const outputDir = (config.output && config.output.path) || process.cwd();
-	const brtOptions = args['build-time-render'];
-	if (brtOptions) {
+	let btrOptions = args['build-time-render'];
+	if (btrOptions) {
+		if (args.singleBundle || (args.experimental && !!args.experimental.speed)) {
+			btrOptions = { ...btrOptions, sync: true };
+		}
 		const jsonpName = (config.output && config.output.jsonpFunction) || 'unknown';
 		const onDemandBtr = new OnDemandBtr({
-			buildTimeRenderOptions: brtOptions,
+			buildTimeRenderOptions: btrOptions,
 			scope: libraryName,
 			base,
 			compiler,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appropriately

**Description:**

Set sync mode for on demand BTR appropriately.