### PR TITLE
Fix code split css asset loads

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -560,7 +560,9 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				{
 					test: /\.(css|js)$/,
 					issuer: indexHtmlPattern,
-					loader: 'file-loader?digest=hex&name=[path][name].[ext]'
+					loader: `file-loader?publicPath=${
+						args.base === undefined ? '/' : args.base
+					}&digest=hex&name=[path][name].[ext]`
 				},
 				tsLint && {
 					include: allPaths,
@@ -639,7 +641,9 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				},
 				{
 					test: /\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2|ico)$/i,
-					loader: 'file-loader?digest=hex&name=[path][name].[ext]'
+					loader: `file-loader?publicPath=${
+						args.base === undefined ? '/' : args.base
+					}&digest=hex&name=[path][name].[ext]`
 				},
 				{
 					test: /\.m\.css\.js$/,

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -560,7 +560,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				{
 					test: /\.(css|js)$/,
 					issuer: indexHtmlPattern,
-					loader: 'file-loader?hash=sha512&digest=hex&name=[name].[hash:base64:8].[ext]'
+					loader: 'file-loader?digest=hex&name=[path][name].[ext]'
 				},
 				tsLint && {
 					include: allPaths,
@@ -639,7 +639,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				},
 				{
 					test: /\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2|ico)$/i,
-					loader: 'file-loader?hash=sha512&digest=hex&name=[name].[hash:base64:8].[ext]'
+					loader: 'file-loader?digest=hex&name=[path][name].[ext]'
 				},
 				{
 					test: /\.m\.css\.js$/,

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -152,7 +152,9 @@ function webpackConfig(args: any): webpack.Configuration {
 					...rule,
 					loader: args.omitHash
 						? rule.loader
-						: 'file-loader?hash=sha512&digest=hex&name=[path][name].[hash:base64:8].[ext]'
+						: `file-loader?publicPath=${
+								args.base === undefined ? '/' : args.base
+						  }&hash=sha512&digest=hex&name=[path][name].[hash:base64:8].[ext]`
 				};
 			}
 

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -144,6 +144,21 @@ function webpackConfig(args: any): webpack.Configuration {
 		}
 		return plugin;
 	});
+	config.module = {
+		...config.module,
+		rules: ((config.module && config.module.rules) || []).map((rule) => {
+			if (rule && typeof rule.loader === 'string' && rule.loader.startsWith('file-loader')) {
+				return {
+					...rule,
+					loader: args.omitHash
+						? rule.loader
+						: 'file-loader?hash=sha512&digest=hex&name=[path][name].[hash:base64:8].[ext]'
+				};
+			}
+
+			return rule;
+		})
+	};
 
 	if (Array.isArray(args.compression)) {
 		const compressionPlugins: any = {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds a publicPath to the file loader config. This may run into the same issues as #316 but I didn't encounter any issues in testing. 
Resolves #315 
