### PR TITLE
fix library name for externals

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -492,7 +492,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 			(args.externals || isTest) &&
 				new WrapperPlugin({
 					test: singleBundle ? new RegExp(`${mainEntry}.*(\.js$)`) : new RegExp(`${bootstrapEntry}.*(\.js$)`),
-					footer: `\ntypeof define === 'function' && define.amd && require(['${libraryName}']);`
+					footer: `\ntypeof define === 'function' && define.amd && require(['lib_${libraryName}']);`
 				}),
 			args.locale && new CldrPlugin(),
 			new webpack.DefinePlugin({


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fix library name for externals.