### PR TITLE
Dont resolve promises on continuous processes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -125,7 +125,7 @@ function buildNpmDependencies(): any {
 	}
 }
 
-async function fileWatch(config: webpack.Configuration, args: any) {
+async function fileWatch(config: webpack.Configuration, args: any, shouldResolve = false) {
 	return new Promise<webpack.Compiler>((resolve, reject) => {
 		const watchOptions = config.watchOptions as webpack.Compiler.WatchOptions;
 		const compiler = createWatchCompiler(config);
@@ -141,13 +141,15 @@ async function fileWatch(config: webpack.Configuration, args: any) {
 					: 'watching...';
 				logger(stats.toJson({ warningsFilter }), config, runningMessage, args);
 			}
-			resolve(compiler);
+			if (shouldResolve) {
+				resolve(compiler);
+			}
 		});
 	});
 }
 
 async function serve(config: webpack.Configuration, args: any) {
-	const compiler = args.watch ? await fileWatch(config, args) : await build(config, args);
+	const compiler = args.watch ? await fileWatch(config, args, true) : await build(config, args);
 	let isHttps = false;
 	const base = args.base || '/';
 
@@ -265,16 +267,12 @@ async function serve(config: webpack.Configuration, args: any) {
 				.listen(args.port, (error: Error) => {
 					if (error) {
 						reject(error);
-					} else {
-						resolve();
 					}
 				});
 		} else {
 			app.listen(args.port, (error: Error) => {
 				if (error) {
 					reject(error);
-				} else {
-					resolve();
 				}
 			});
 		}


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Testing all the permutations against an actual app (`-w -s`, `-w`, and `-s` in and out of a package.json script) this seems to work, but if we go with this a lot of unit tests will become pretty awkward. Maybe we should adjust these promises to resolve with a boolean depending on whether the process will continue on and update `cli` accordingly?
Resolves #407 
