### PR TITLE
Align schema with usage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -315,13 +315,13 @@ const command: Command = {
 			type: 'number'
 		});
 
-		options('singleBundle', {
+		options('single-bundle', {
 			describe: 'limits the built output to a single bundle',
 			default: false,
 			type: 'boolean'
 		});
 
-		options('omitHash', {
+		options('omit-hash', {
 			describe: 'omits hashes from output file names in dist mode',
 			defaultDescription: '(always false for dev builds)',
 			default: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -315,13 +315,13 @@ const command: Command = {
 			type: 'number'
 		});
 
-		options('single-bundle', {
+		options('singleBundle', {
 			describe: 'limits the built output to a single bundle',
 			default: false,
 			type: 'boolean'
 		});
 
-		options('omit-hash', {
+		options('omitHash', {
 			describe: 'omits hashes from output file names in dist mode',
 			defaultDescription: '(always false for dev builds)',
 			default: false,

--- a/src/schema.json
+++ b/src/schema.json
@@ -34,10 +34,10 @@
 				}
 			}
 		},
-		"single-bundle": {
+		"singleBundle": {
 			"type": "boolean"
 		},
-		"omit-hash": {
+		"omitHash": {
 			"type": "boolean"
 		},
 		"bundles": {
@@ -469,11 +469,11 @@
 		"f": {
 			"$ref": "#/definitions/features"
 		},
-		"single-bundle": {
-			"$ref": "#/definitions/single-bundle"
+		"singleBundle": {
+			"$ref": "#/definitions/singleBundle"
 		},
-		"omit-hash": {
-			"$ref": "#/definitions/omit-hash"
+		"omitHash": {
+			"$ref": "#/definitions/omitHash"
 		},
 		"bundles": {
 			"$ref": "#/definitions/bundles"


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [x] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
`omit-hash` and `single-bundle` in the schema and arg config don't align with the expected values `omitHash` and `singleBundle` in the actual build config code. Most other properties seem to follow the camel case pattern so this applies the same to these properties.

Resolves #410 