### PR TITLE
Fix bugs introduced in #416

### DIFF
--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -170,10 +170,19 @@ function webpackConfig(args: any): webpack.Configuration {
 	if (Array.isArray(args.compression)) {
 		args.compression.forEach((algorithm: 'brotli' | 'gzip') => {
 			config.plugins!.push(
-				new CompressionPlugin({
-					algorithm: algorithm === 'brotli' ? 'brotliCompress' : 'gzip',
-					test: /\.(js|css|html|svg)$/
-				})
+				new CompressionPlugin(
+					algorithm === 'brotli'
+						? {
+								filename: '[path].br[query]',
+								algorithm: 'brotliCompress',
+								test: /\.(js|css|html|svg)$/,
+								cache: false
+						  }
+						: {
+								test: /\.(js|css|html|svg)$/,
+								cache: false
+						  }
+				)
 			);
 		});
 	}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -29,9 +29,13 @@ export default function logger(stats: any, config: any, runningMessage: string =
 				} else {
 					const fileStats = fs.statSync(filePath);
 					const size = (fileStats.size / 1000).toFixed(2);
-					const assetInfo = `${assetName} ${chalk.yellow(`(${size}kb)`)}`;
+					if (/\.(gz|br)$/.test(filePath)) {
+						return `${assetName} ${chalk.blue(`(${size}kb)`)}`;
+					}
+					// Calculate and report size when gzipped
 					const content = fs.readFileSync(filePath, 'utf8');
 					const compressedSize = (gzipSize.sync(content) / 1000).toFixed(2);
+					const assetInfo = `${assetName} ${chalk.yellow(`(${size}kb)`)}`;
 					return `${assetInfo} / ${chalk.blue(`(${compressedSize}kb gz)`)}`;
 				}
 			}


### PR DESCRIPTION
Sorry, I didn't properly test the previous MR. The compression plugin isn't as clever as I hoped and you have to specify the file name. Furthermore I've decided to disable cache due to https://github.com/webpack-contrib/compression-webpack-plugin/issues/170 which was quite a headache during testing.

To make the bugs I introduced a bit less painful I decided to update the CLI marginally for compressed outputs too.

![image](https://user-images.githubusercontent.com/335152/87560062-f7144300-c6b2-11ea-9f68-0743668a5170.png)

So we don't try to get the gzipped size of already compressed otuputs.