### PR TITLE
Fix loading images from code split CSS and maintain dev structure/remove hashes from all dev assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4886,6 +4886,16 @@
         "source-map": "^0.6.1"
       }
     },
+    "css-url-relative-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-url-relative-plugin/-/css-url-relative-plugin-1.0.0.tgz",
+      "integrity": "sha1-T4FVU2I2Tw8ZG9HFKLwnsKdqFGw=",
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "parse-import": "^2.0.0",
+        "webpack-sources": "^1.1.0"
+      }
+    },
     "css-vars-ponyfill": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.3.0.tgz",
@@ -7381,6 +7391,15 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-imports": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-imports/-/get-imports-1.0.0.tgz",
+      "integrity": "sha1-R8C07piTUWQsVJdxk79Pyqv1N48=",
+      "requires": {
+        "array-uniq": "^1.0.1",
+        "import-regex": "^1.1.0"
+      }
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -8672,6 +8691,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
       "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ=="
+    },
+    "import-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/import-regex/-/import-regex-1.1.0.tgz",
+      "integrity": "sha1-pVxS5McFx2XKIQ6SQqBrvMiqf2Y="
     },
     "imports-loader": {
       "version": "0.8.0",
@@ -12515,6 +12539,14 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
       "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
+    },
+    "parse-import": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-import/-/parse-import-2.0.0.tgz",
+      "integrity": "sha1-KyR0Aw4AirmNt2xLy/TbWucwb18=",
+      "requires": {
+        "get-imports": "^1.0.0"
+      }
     },
     "parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "connect-history-api-fallback": "1.5.0",
     "connect-inject": "0.4.0",
     "css-loader": "1.0.1",
-    "css-url-relative-plugin": "^1.0.0",
+    "css-url-relative-plugin": "1.0.0",
     "cssnano": "4.1.7",
     "express": "4.16.2",
     "express-static-gzip": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "connect-history-api-fallback": "1.5.0",
     "connect-inject": "0.4.0",
     "css-loader": "1.0.1",
+    "css-url-relative-plugin": "^1.0.0",
     "cssnano": "4.1.7",
     "express": "4.16.2",
     "express-static-gzip": "1.1.3",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -560,7 +560,9 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				{
 					test: /\.(css|js)$/,
 					issuer: indexHtmlPattern,
-					loader: 'file-loader?digest=hex&name=[path][name].[ext]'
+					loader: `file-loader?publicPath=${
+						args.base === undefined ? '/' : args.base
+					}&digest=hex&name=[path][name].[ext]`
 				},
 				tsLint && {
 					include: allPaths,
@@ -639,7 +641,9 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				},
 				{
 					test: /\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2|ico)$/i,
-					loader: 'file-loader?digest=hex&name=[path][name].[ext]'
+					loader: `file-loader?publicPath=${
+						args.base === undefined ? '/' : args.base
+					}&digest=hex&name=[path][name].[ext]`
 				},
 				{
 					test: /\.m\.css\.js$/,

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -14,6 +14,7 @@ import * as minimatch from 'minimatch';
 import * as ManifestPlugin from 'webpack-manifest-plugin';
 import * as globby from 'globby';
 
+const CssUrlRelativePlugin = require('css-url-relative-plugin');
 const postcssPresetEnv = require('postcss-preset-env');
 const postcssImport = require('postcss-import');
 const slash = require('slash');
@@ -542,7 +543,8 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				new ExtraWatchWebpackPlugin({
 					files: watchExtraFiles
 				}),
-			new ManifestPlugin()
+			new ManifestPlugin(),
+			new CssUrlRelativePlugin({ root: args.base || '/' })
 		]),
 		module: {
 			// `file` uses the pattern `loaderPath!filePath`, hence the regex test
@@ -560,9 +562,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				{
 					test: /\.(css|js)$/,
 					issuer: indexHtmlPattern,
-					loader: `file-loader?publicPath=${
-						args.base === undefined ? '/' : args.base
-					}&digest=hex&name=[path][name].[ext]`
+					loader: `file-loader?digest=hex&name=[path][name].[ext]`
 				},
 				tsLint && {
 					include: allPaths,
@@ -641,9 +641,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				},
 				{
 					test: /\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2|ico)$/i,
-					loader: `file-loader?publicPath=${
-						args.base === undefined ? '/' : args.base
-					}&digest=hex&name=[path][name].[ext]`
+					loader: `file-loader?digest=hex&name=[path][name].[ext]`
 				},
 				{
 					test: /\.m\.css\.js$/,

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -560,7 +560,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				{
 					test: /\.(css|js)$/,
 					issuer: indexHtmlPattern,
-					loader: 'file-loader?hash=sha512&digest=hex&name=[name].[hash:base64:8].[ext]'
+					loader: 'file-loader?digest=hex&name=[path][name].[ext]'
 				},
 				tsLint && {
 					include: allPaths,
@@ -639,7 +639,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				},
 				{
 					test: /\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2|ico)$/i,
-					loader: 'file-loader?hash=sha512&digest=hex&name=[name].[hash:base64:8].[ext]'
+					loader: 'file-loader?digest=hex&name=[path][name].[ext]'
 				},
 				{
 					test: /\.m\.css\.js$/,

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -174,9 +174,7 @@ function webpackConfig(args: any): webpack.Configuration {
 					...rule,
 					loader: args.omitHash
 						? rule.loader
-						: `file-loader?publicPath=${
-								args.base === undefined ? '/' : args.base
-						  }&hash=sha512&digest=hex&name=[path][name].[hash:base64:8].[ext]`
+						: `file-loader?hash=sha512&digest=hex&name=[path][name].[hash:base64:8].[ext]`
 				};
 			}
 

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -174,7 +174,9 @@ function webpackConfig(args: any): webpack.Configuration {
 					...rule,
 					loader: args.omitHash
 						? rule.loader
-						: 'file-loader?hash=sha512&digest=hex&name=[path][name].[hash:base64:8].[ext]'
+						: `file-loader?publicPath=${
+								args.base === undefined ? '/' : args.base
+						  }&hash=sha512&digest=hex&name=[path][name].[hash:base64:8].[ext]`
 				};
 			}
 

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -166,6 +166,21 @@ function webpackConfig(args: any): webpack.Configuration {
 		}
 		return plugin;
 	});
+	config.module = {
+		...config.module,
+		rules: ((config.module && config.module.rules) || []).map((rule) => {
+			if (rule && typeof rule.loader === 'string' && rule.loader.startsWith('file-loader')) {
+				return {
+					...rule,
+					loader: args.omitHash
+						? rule.loader
+						: 'file-loader?hash=sha512&digest=hex&name=[path][name].[hash:base64:8].[ext]'
+				};
+			}
+
+			return rule;
+		})
+	};
 
 	if (Array.isArray(args.compression)) {
 		args.compression.forEach((algorithm: 'brotli' | 'gzip') => {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
@matt-gadd This is basically the original solution I tried to implement for these issues that keeps the folder structure for all files and removes the hashes that were being included in some files in dev. The difference is the addition of a dependency on a plugin that resolves the issues we were running into with asset paths in css `url()`s for code split files and dynamic public paths.    
Resolves #314 #315 
