### PR TITLE
Adding writeCss to schema (webpack-contrib #283)

### DIFF
--- a/src/schema.json
+++ b/src/schema.json
@@ -110,6 +110,9 @@
 				},
 				"writeHtml": {
 					"type": "boolean"
+				},
+				"writeCss": {
+					"type": "boolean"
 				}
 			}
 		},


### PR DESCRIPTION
**Type:**feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [x] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding `writeCss` to the BTR schema

Support for https://github.com/dojo/webpack-contrib/issues/283
