### PR TITLE
Fixing relative base path serving #363

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -357,6 +357,7 @@ const command: Command = {
 		console.log = () => {};
 		let config: webpack.Configuration;
 		args.experimental = args.experimental || {};
+		args.base = url.resolve('/', `${args.base || ''}/`).replace(/\/{2,}$/, '/');
 
 		if (args.mode === 'dev') {
 			config = devConfigFactory(args);

--- a/src/main.ts
+++ b/src/main.ts
@@ -357,7 +357,10 @@ const command: Command = {
 		console.log = () => {};
 		let config: webpack.Configuration;
 		args.experimental = args.experimental || {};
-		args.base = url.resolve('/', `${args.base || ''}/`).replace(/\/{2,}$/, '/');
+		args.base = url.resolve('/', args.base || '');
+		if (!args.base.endsWith('/')) {
+			args.base = `${args.base}/`;
+		}
 
 		if (args.mode === 'dev') {
 			config = devConfigFactory(args);

--- a/test-app/.dojorc-dev-app
+++ b/test-app/.dojorc-dev-app
@@ -1,6 +1,6 @@
 {
 	"build-app": {
-		"base": "/test-app/output/dev-app/",
+		"base": "test-app/output/dev-app",
 		"mode": "dev",
 		"legacy": true,
 		"compression": [ "gzip", "brotli" ],


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing an issue in which using a relative path as your `base` path makes the application unable to be served by the express server.

To fix this, the relative path is turned into an absolute path (resolved against `/`) and gets another `/` appended to the end. This value is then used as both the express root and the `<base>` tag's value. 

Resolves #363 
