### PR TITLE
Try proxy before serving static

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -206,6 +206,19 @@ async function serve(configs: webpack.Configuration[], args: any) {
 			]
 		})
 	);
+
+	if (args.proxy) {
+		Object.keys(args.proxy).forEach((context) => {
+			const options = args.proxy[context];
+
+			if (typeof options === 'string') {
+				app.use(base, proxy(context, { target: options }));
+			} else {
+				app.use(base, proxy(context, options));
+			}
+		});
+	}
+
 	serveStatic(app, outputDir, args.mode, args.compression, base);
 
 	app.use(
@@ -236,18 +249,6 @@ async function serve(configs: webpack.Configuration[], args: any) {
 	);
 
 	serveStatic(app, outputDir, args.mode, args.compression, base);
-
-	if (args.proxy) {
-		Object.keys(args.proxy).forEach((context) => {
-			const options = args.proxy[context];
-
-			if (typeof options === 'string') {
-				app.use(base, proxy(context, { target: options }));
-			} else {
-				app.use(base, proxy(context, options));
-			}
-		});
-	}
 
 	const defaultKey = path.resolve('.cert', 'server.key');
 	const defaultCrt = path.resolve('.cert', 'server.crt');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR
* [x] schema.json has been updated appropriately

**Description:**

Moves the proxy logic before the logic that deals with serving static so get requests are not re-written to the index page.