### PR TITLE
Parse https proxies automatically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -366,9 +366,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -1088,9 +1088,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.4.tgz",
-          "integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w=="
+          "version": "12.19.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.5.tgz",
+          "integrity": "sha512-Wgdl27uw/jUYUFyajUGKSjDNGxmJrZi9sjeG6UJImgUtKbJoO9aldx+1XODN1EpNDX9DirvbvHHmTsNlb8GwMA=="
         },
         "camelcase": {
           "version": "4.1.0",
@@ -1644,9 +1644,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-          "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg=="
+          "version": "14.14.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.8.tgz",
+          "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA=="
         }
       }
     },
@@ -1898,9 +1898,9 @@
       }
     },
     "@types/serve-static": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.7.tgz",
-      "integrity": "sha512-3diZWucbR+xTmbDlU+FRRxBf+31OhFew7cJXML/zh9NmvSPTNoFecAwHB66BUqFgENJtqMiyl7JAwUE/siqdLw==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
+      "integrity": "sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==",
       "dev": true,
       "requires": {
         "@types/mime": "*",
@@ -1966,9 +1966,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-          "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg=="
+          "version": "14.14.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.8.tgz",
+          "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA=="
         }
       }
     },
@@ -2687,9 +2687,9 @@
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001158",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz",
-          "integrity": "sha512-s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g=="
+          "version": "1.0.30001159",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
+          "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA=="
         },
         "chalk": {
           "version": "2.4.2",
@@ -3644,9 +3644,9 @@
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001158",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz",
-          "integrity": "sha512-s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g=="
+          "version": "1.0.30001159",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
+          "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA=="
         }
       }
     },
@@ -5717,18 +5717,18 @@
       },
       "dependencies": {
         "css-tree": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.1.tgz",
-          "integrity": "sha512-WroX+2MvsYcRGP8QA0p+rxzOniT/zpAoQ/DTKDSJzh5T3IQKUkFHeIIfgIapm2uaP178GWY3Mime1qbk8GO/tA==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.1.tgz",
+          "integrity": "sha512-NVN42M2fjszcUNpDbdkvutgQSlFYsr1z7kqeuCagHnNLBfYor6uP1WL1KrkmdYZ5Y1vTBCIOI/C/+8T98fJ71w==",
           "requires": {
-            "mdn-data": "2.0.12",
+            "mdn-data": "2.0.14",
             "source-map": "^0.6.1"
           }
         },
         "mdn-data": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.12.tgz",
-          "integrity": "sha512-ULbAlgzVb8IqZ0Hsxm6hHSlQl3Jckst2YEQS7fODu9ilNWy2LvcoSY7TRFIktABP2mdppBioc66va90T+NUs8Q=="
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
         }
       }
     },
@@ -6215,9 +6215,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -6832,9 +6832,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.4.tgz",
-          "integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w=="
+          "version": "12.19.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.5.tgz",
+          "integrity": "sha512-Wgdl27uw/jUYUFyajUGKSjDNGxmJrZi9sjeG6UJImgUtKbJoO9aldx+1XODN1EpNDX9DirvbvHHmTsNlb8GwMA=="
         }
       }
     },
@@ -6934,9 +6934,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.596",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.596.tgz",
-      "integrity": "sha512-nLO2Wd2yU42eSoNJVQKNf89CcEGqeFZd++QsnN2XIgje1s/19AgctfjLIbPORlvcCO8sYjLwX4iUgDdusOY8Sg=="
+      "version": "1.3.601",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.601.tgz",
+      "integrity": "sha512-ctRyXD9y0mZu8pgeNwBUhLP3Guyr5YuqkfLKYmpTwYx7o9JtCEJme9JVX4xBXPr5ZNvr/iBXUvHLFEVJQThATg=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -8676,9 +8676,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -9591,9 +9591,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -11135,9 +11135,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -13376,9 +13376,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.66",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.66.tgz",
-      "integrity": "sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg=="
+      "version": "1.1.67",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
     },
     "node-status-codes": {
       "version": "1.0.0",
@@ -17772,9 +17772,9 @@
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001158",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz",
-          "integrity": "sha512-s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g=="
+          "version": "1.0.30001159",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
+          "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA=="
         },
         "chalk": {
           "version": "2.4.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -215,13 +215,17 @@ async function serve(configs: webpack.Configuration[], args: any, esbuild = fals
 
 	if (args.proxy) {
 		Object.keys(args.proxy).forEach((context) => {
-			const options = args.proxy[context];
+			const options =
+				typeof args.proxy[context] === 'string' ? { target: args.proxy[context] } : args.proxy[context];
 
-			if (typeof options === 'string') {
-				app.use(base, proxy(context, { target: options }));
-			} else {
-				app.use(base, proxy(context, options));
+			const parsedTarget = url.parse(options.target);
+			if (parsedTarget.protocol === 'https:') {
+				options.agent = https.globalAgent;
+				options.headers = {
+					host: parsedTarget.host
+				};
 			}
+			app.use(base, proxy(context, options));
 		});
 	}
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [x] Unit or Functional tests are included in the PR
* [x] schema.json has been updated appropriately

**Description:**

If a https target is specified in the dojorc add the appropriate configuration to support the proxy configuration

