### PR TITLE
Add support for Build Time Render Cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -321,6 +321,12 @@
             "restore-cursor": "^1.0.1"
           }
         },
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+          "dev": true
+        },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -869,13 +875,13 @@
       }
     },
     "@dojo/framework": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.5.tgz",
-      "integrity": "sha512-GO+KEiywtsPcbGuDuGWV2JRWZgQwGlQoJG6aypSRpgw993bj6liguqG+4G6frmk6Rbiw8J7IrNh5xjaXEta50g==",
+      "version": "8.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-8.0.0-alpha.6.tgz",
+      "integrity": "sha512-nmGRCZNLjwMQq2TnTzippENPpUgvJJOMlDTmNTEc65fFfty34SfcB0i7Ehv2eB3D0H9Tu99rRSA1KGXGM99mFA==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
-        "@webcomponents/webcomponentsjs": "1.1.0",
+        "@webcomponents/webcomponentsjs": "2.5.0",
         "cldr-core": "36.0.0",
         "cldrjs": "^0.5.0",
         "cross-fetch": "3.0.2",
@@ -1040,11 +1046,12 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "8.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-8.0.0-alpha.1.tgz",
-      "integrity": "sha512-7pjbALd//LmpBCdIgaEQ/0rBJlIZqFuI0aU++QaG9HSKG8f2GoOqofN5LTIxhDeYH2y79xIDnHRPmDz9mAr0UQ==",
+      "version": "8.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-8.0.0-alpha.2.tgz",
+      "integrity": "sha512-WvbpZ0JqYeg/8D6BQ4+czSEZ8hm9rcVTNKHqdy4sy/Kqsa9Ncl1iC9fYJM+FFOq981hHlTmQ3xtJT4lGho3ChA==",
       "requires": {
-        "@dojo/framework": "~7.0.2",
+        "@dojo/framework": "8.0.0-alpha.6",
+        "@msgpack/msgpack": "2.3.0",
         "acorn": "6.1.1",
         "acorn-dynamic-import": "4.0.0",
         "acorn-walk": "6.1.1",
@@ -1075,6 +1082,7 @@
         "mkdirp": "0.5.1",
         "node-html-parser": "1.2.20",
         "opener": "1.4.3",
+        "ora": "5.0.0",
         "postcss": "7.0.7",
         "puppeteer": "1.11.0",
         "recast": "0.12.7",
@@ -1088,9 +1096,14 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.5.tgz",
-          "integrity": "sha512-Wgdl27uw/jUYUFyajUGKSjDNGxmJrZi9sjeG6UJImgUtKbJoO9aldx+1XODN1EpNDX9DirvbvHHmTsNlb8GwMA=="
+          "version": "12.19.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
+          "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg=="
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "camelcase": {
           "version": "4.1.0",
@@ -1106,6 +1119,24 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^4.0.0"
           }
+        },
+        "cli-spinners": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
+          "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ=="
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "connect-history-api-fallback": {
           "version": "1.6.0",
@@ -1128,9 +1159,86 @@
           }
         },
         "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "log-symbols": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "requires": {
+            "chalk": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "chalk": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+              "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "ora": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.0.0.tgz",
+          "integrity": "sha512-s26qdWqke2kjN/wC4dy+IQPBIMWBJlSU/0JZhk30ZDBLelW25rv66yutUWARMigpGPzcXHb+Nac5pNhN/WsARw==",
+          "requires": {
+            "chalk": "^4.1.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.4.0",
+            "is-interactive": "^1.0.0",
+            "log-symbols": "^4.0.0",
+            "mute-stream": "0.0.8",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "chalk": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+              "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
         },
         "postcss": {
           "version": "7.0.7",
@@ -1152,6 +1260,11 @@
                 "supports-color": "^5.3.0"
               }
             },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            },
             "supports-color": {
               "version": "5.5.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1166,6 +1279,14 @@
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
         },
         "ts-loader": {
           "version": "5.4.5",
@@ -1244,6 +1365,11 @@
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
       }
+    },
+    "@msgpack/msgpack": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.3.0.tgz",
+      "integrity": "sha512-xxRejzNpiVQ2lzxMG/yo2ocfZSk+cKo2THq54AimaubMucg66DpQm9Yj7ESMr/l2EqDkmF2Dx4r0F/cbsitAaw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -2227,9 +2353,9 @@
       }
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.1.0.tgz",
-      "integrity": "sha512-7toNyVlrl7vJnY3PU0eXIK1KWq8phfnEe1IwOdCMxkIl/BfUkUB2aaVs45R0LSx1qxHRnkqj0vlGtskUvKkNkA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -4256,6 +4382,11 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+    },
     "clone-regexp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
@@ -6209,10 +6340,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
+      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
     },
     "debug": {
       "version": "4.3.1",
@@ -6399,6 +6529,14 @@
             "is-utf8": "^0.2.0"
           }
         }
+      }
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "^1.0.2"
       }
     },
     "defer-to-connect": {
@@ -10778,6 +10916,11 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
+    },
     "is-jpg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-2.0.0.tgz",
@@ -11776,6 +11919,12 @@
             "figures": "^2.0.0"
           },
           "dependencies": {
+            "date-fns": {
+              "version": "1.30.1",
+              "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+              "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+              "dev": true
+            },
             "figures": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -12206,6 +12355,12 @@
           "requires": {
             "restore-cursor": "^1.0.1"
           }
+        },
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+          "dev": true
         },
         "figures": {
           "version": "1.7.0",
@@ -18727,14 +18882,6 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
           "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
         "ws": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -18883,9 +19030,9 @@
       }
     },
     "rcedit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-2.2.0.tgz",
-      "integrity": "sha512-dhFtYmQS+V8qQIANyX6zDK+sO50ayDePKApi46ZPK8I6QeyyTDD6LManMa7a3p3c9mLM4zi9QBP41pfhQ9p7Sg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-2.3.0.tgz",
+      "integrity": "sha512-h1gNEl9Oai1oijwyJ1WYqYSXTStHnOcv1KYljg/8WM4NAg3H1KBK3azIaKkQ1WQl+d7PoJpcBMscPfLXVKgCLQ=="
     },
     "read-all-stream": {
       "version": "3.1.0",
@@ -18993,9 +19140,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         }
       }
     },
@@ -19366,7 +19513,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -22744,6 +22890,14 @@
       "optional": true,
       "requires": {
         "chokidar": "^2.1.8"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "web-animations-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,9 +1046,9 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "8.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-8.0.0-alpha.2.tgz",
-      "integrity": "sha512-WvbpZ0JqYeg/8D6BQ4+czSEZ8hm9rcVTNKHqdy4sy/Kqsa9Ncl1iC9fYJM+FFOq981hHlTmQ3xtJT4lGho3ChA==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-wRSJ7PIiF56v8f7jXcr2DEM9qTVG7/NaWTv1QXk2n3YIs3BnBfi9fOWiA5JFS1VoWcIG13BmBZUcjoYHxMyQ3w==",
       "requires": {
         "@dojo/framework": "8.0.0-alpha.6",
         "@msgpack/msgpack": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "tslint": "5.18.0"
   },
   "dependencies": {
-    "@dojo/webpack-contrib": "8.0.0-alpha.1",
+    "@dojo/webpack-contrib": "8.0.0-alpha.2",
     "@parcel/watcher": "2.0.0-alpha.9",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
@@ -120,6 +120,7 @@
     "css-loader": "1.0.1",
     "css-url-relative-plugin": "1.0.0",
     "cssnano": "4.1.7",
+    "date-fns": "^2.16.1",
     "electron": "10.1.1",
     "esbuild": "0.8.5",
     "eslint": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "tslint": "5.18.0"
   },
   "dependencies": {
-    "@dojo/webpack-contrib": "8.0.0-alpha.2",
+    "@dojo/webpack-contrib": "8.0.0-alpha.3",
     "@parcel/watcher": "2.0.0-alpha.9",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "css-loader": "1.0.1",
     "css-url-relative-plugin": "1.0.0",
     "cssnano": "4.1.7",
-    "date-fns": "^2.16.1",
+    "date-fns": "2.16.1",
     "electron": "10.1.1",
     "esbuild": "0.8.5",
     "eslint": "7.0.0",

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -131,7 +131,7 @@ window['${libraryName}'].base = '${base}'</script>`,
 				baseUrl: base,
 				scope: libraryName,
 				onDemand: Boolean(args.serve && args.watch),
-				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-paths'] }
+				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-cache-paths'] }
 			})
 		);
 	}

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -131,7 +131,7 @@ window['${libraryName}'].base = '${base}'</script>`,
 				baseUrl: base,
 				scope: libraryName,
 				onDemand: Boolean(args.serve && args.watch),
-				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-cache-paths'] || [] }
+				cacheOptions: { ...cacheOptions, invalidates: [] }
 			})
 		);
 	}

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -131,7 +131,7 @@ window['${libraryName}'].base = '${base}'</script>`,
 				baseUrl: base,
 				scope: libraryName,
 				onDemand: Boolean(args.serve && args.watch),
-				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-cache-paths'] }
+				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-cache-paths'] || [] }
 			})
 		);
 	}

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -119,16 +119,19 @@ window['${libraryName}'].base = '${base}'</script>`,
 		});
 	}
 
-	if (args['build-time-render']) {
+	const btr = args['build-time-render'];
+	if (btr) {
+		const cacheOptions = btr.cache || { enabled: false, excludes: [] };
 		config.plugins.push(
 			new BuildTimeRender({
-				...args['build-time-render'],
+				...btr,
 				sync: singleBundle,
 				entries: Object.keys(config.entry!),
 				basePath,
 				baseUrl: base,
 				scope: libraryName,
-				onDemand: Boolean(args.serve && args.watch)
+				onDemand: Boolean(args.serve && args.watch),
+				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-paths'] }
 			})
 		);
 	}

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -156,7 +156,7 @@ function webpackConfig(args: any): webpack.Configuration {
 				baseUrl: base,
 				scope: libraryName,
 				onDemand: Boolean(args.serve && args.watch),
-				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-cache-paths'] }
+				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-cache-paths'] || [] }
 			})
 		);
 	}

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -156,7 +156,7 @@ function webpackConfig(args: any): webpack.Configuration {
 				baseUrl: base,
 				scope: libraryName,
 				onDemand: Boolean(args.serve && args.watch),
-				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-cache-paths'] || [] }
+				cacheOptions: { ...cacheOptions, invalidates: [] }
 			})
 		);
 	}

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -156,7 +156,7 @@ function webpackConfig(args: any): webpack.Configuration {
 				baseUrl: base,
 				scope: libraryName,
 				onDemand: Boolean(args.serve && args.watch),
-				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-paths'] }
+				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-cache-paths'] }
 			})
 		);
 	}

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -144,16 +144,19 @@ function webpackConfig(args: any): webpack.Configuration {
 		new CleanWebpackPlugin(['dist', 'info'], { root: output!.path, verbose: false })
 	].filter((item) => item);
 
-	if (args['build-time-render']) {
+	const btr = args['build-time-render'];
+	if (btr) {
+		const cacheOptions = btr.cache || { enabled: false, excludes: [] };
 		config.plugins.push(
 			new BuildTimeRender({
-				...args['build-time-render'],
+				...btr,
 				entries: Object.keys(config.entry!),
 				sync: args.singleBundle,
 				basePath,
 				baseUrl: base,
 				scope: libraryName,
-				onDemand: Boolean(args.serve && args.watch)
+				onDemand: Boolean(args.serve && args.watch),
+				cacheOptions: { ...cacheOptions, invalidates: args['invalidate-btr-paths'] }
 			})
 		);
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import * as expressCompression from 'compression';
 import * as proxy from 'http-proxy-middleware';
 import * as history from 'connect-history-api-fallback';
 import OnDemandBtr from '@dojo/webpack-contrib/build-time-render/BuildTimeRenderMiddleware';
+import { read as readCache } from '@dojo/webpack-contrib/build-time-render/cache';
 
 const pkgDir = require('pkg-dir');
 const expressStaticGzip = require('express-static-gzip');
@@ -397,9 +398,15 @@ const command: Command = {
 			});
 
 		!esBuild &&
-			options('invalidate-btr-paths', {
+			options('invalidate-btr-cache-paths', {
 				describe: 'invalidate paths in the Build Time Render cache',
 				array: true
+			});
+
+		!esBuild &&
+			options('list-btr-cache-paths', {
+				describe: 'list the paths and times in the Build Time Render cache',
+				type: 'boolean'
 			});
 	},
 	run(helper: Helper, args: any) {
@@ -409,6 +416,12 @@ const command: Command = {
 		args.base = url.resolve('/', args.base || '');
 		if (!args.base.endsWith('/')) {
 			args.base = `${args.base}/`;
+		}
+
+		if (args['list-btr-cache-paths']) {
+			return readCache().then((cache) => {
+				console.log(cache);
+			});
 		}
 
 		if (args.fast) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import * as proxy from 'http-proxy-middleware';
 import * as history from 'connect-history-api-fallback';
 import OnDemandBtr from '@dojo/webpack-contrib/build-time-render/BuildTimeRenderMiddleware';
 import { read as readCache } from '@dojo/webpack-contrib/build-time-render/cache';
+import { formatDistance } from 'date-fns';
 const columns = require('cli-columns');
 
 const pkgDir = require('pkg-dir');
@@ -420,8 +421,13 @@ const command: Command = {
 		}
 
 		if (args['list-btr-cache-paths']) {
-			return readCache().then(({ paths }) => {
-				const column = Object.keys(paths).map((path) => `${chalk.yellow(path)} (${paths[path].time})`);
+			return readCache().then(({ pages }) => {
+				const column = Object.keys(pages).map((page) => {
+					const result = formatDistance(new Date(pages[page].time!), new Date(Date.now()), {
+						addSuffix: true
+					});
+					return `${page} ${chalk.blue('(' + result + ')')}`;
+				});
 				logUpdate(columns(column));
 			});
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import * as proxy from 'http-proxy-middleware';
 import * as history from 'connect-history-api-fallback';
 import OnDemandBtr from '@dojo/webpack-contrib/build-time-render/BuildTimeRenderMiddleware';
 import { read as readCache } from '@dojo/webpack-contrib/build-time-render/cache';
+const columns = require('cli-columns');
 
 const pkgDir = require('pkg-dir');
 const expressStaticGzip = require('express-static-gzip');
@@ -419,8 +420,9 @@ const command: Command = {
 		}
 
 		if (args['list-btr-cache-paths']) {
-			return readCache().then((cache) => {
-				console.log(cache);
+			return readCache().then(({ paths }) => {
+				const column = Object.keys(paths).map((path) => `${chalk.yellow(path)} (${paths[path].time})`);
+				logUpdate(columns(column));
 			});
 		}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -395,6 +395,12 @@ const command: Command = {
 					);
 				}
 			});
+
+		!esBuild &&
+			options('invalidate-btr-paths', {
+				describe: 'invalidate paths in the Build Time Render cache',
+				array: true
+			});
 	},
 	run(helper: Helper, args: any) {
 		console.log = () => {};

--- a/src/schema.json
+++ b/src/schema.json
@@ -113,6 +113,19 @@
 				"puppeteerOptions": {
 					"type": "object"
 				},
+				"cache": {
+					"type": "object",
+					"properties": {
+						"enabled": { "type": "boolean" },
+						"excludes": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						}
+					},
+					"additionalProperties": false
+				},
 				"renderer": {
 					"type": "string",
 					"enum": [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [x] schema.json has been updated appopriately

**Description:**
Adds a cache to Build Time Render to drastically speed up build times. This can be invalidated with the `--evict-cache-paths` option (which supports globs). You can see the contents of the cache with `--list-cache-paths` which will show last cached date also. To enable the cache add the following to the build-time-render options in the .dojorc:

```json
"cache": {
  "enabled": true
}
```
You can also add exclude paths like the following (it supports globs also):

```json
"cache": {
  "exclude":  [ "foo/**" ]
}
```

The cache itself is completely opaque and should not be modified by the user directly. Its designed to be stored and committed in the users project .