### PR TITLE
Manual revert of 423

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5604,16 +5604,6 @@
         "source-map": "^0.6.1"
       }
     },
-    "css-url-relative-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-url-relative-plugin/-/css-url-relative-plugin-1.0.0.tgz",
-      "integrity": "sha1-T4FVU2I2Tw8ZG9HFKLwnsKdqFGw=",
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "parse-import": "^2.0.0",
-        "webpack-sources": "^1.1.0"
-      }
-    },
     "css-vars-ponyfill": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.3.0.tgz",
@@ -7073,9 +7063,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.614",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.614.tgz",
-      "integrity": "sha512-JMDl46mg4G+n6q/hAJkwy9eMTj5FJjsE+8f/irAGRMLM4yeRVbMuRrdZrbbGGOrGVcZc4vJPjUpEUWNb/fA6hg=="
+      "version": "1.3.615",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.615.tgz",
+      "integrity": "sha512-fNYTQXoUhNc6RmHDlGN4dgcLURSBIqQCN7ls6MuQ741+NJyLNRz8DxAC+pZpOKfRs6cfY0lv2kWdy8Oxf9j4+A=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -8859,15 +8849,6 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
-    "get-imports": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-imports/-/get-imports-1.0.0.tgz",
-      "integrity": "sha1-R8C07piTUWQsVJdxk79Pyqv1N48=",
-      "requires": {
-        "array-uniq": "^1.0.1",
-        "import-regex": "^1.1.0"
-      }
-    },
     "get-intrinsic": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
@@ -10183,11 +10164,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
       "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ=="
-    },
-    "import-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/import-regex/-/import-regex-1.1.0.tgz",
-      "integrity": "sha1-pVxS5McFx2XKIQ6SQqBrvMiqf2Y="
     },
     "imports-loader": {
       "version": "0.8.0",
@@ -14365,14 +14341,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
       "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
-    },
-    "parse-import": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-import/-/parse-import-2.0.0.tgz",
-      "integrity": "sha1-KyR0Aw4AirmNt2xLy/TbWucwb18=",
-      "requires": {
-        "get-imports": "^1.0.0"
-      }
     },
     "parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "connect-history-api-fallback": "1.5.0",
     "connect-inject": "0.4.0",
     "css-loader": "1.0.1",
-    "css-url-relative-plugin": "1.0.0",
     "cssnano": "4.1.7",
     "date-fns": "2.16.1",
     "electron": "10.1.1",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -14,7 +14,6 @@ import * as minimatch from 'minimatch';
 import * as ManifestPlugin from 'webpack-manifest-plugin';
 import * as globby from 'globby';
 
-const CssUrlRelativePlugin = require('css-url-relative-plugin');
 const postcssPresetEnv = require('postcss-preset-env');
 const postcssImport = require('postcss-import');
 const slash = require('slash');
@@ -544,8 +543,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				new ExtraWatchWebpackPlugin({
 					files: watchExtraFiles
 				}),
-			new ManifestPlugin(),
-			new CssUrlRelativePlugin({ root: base || '/' })
+			new ManifestPlugin()
 		]),
 		module: {
 			// `file` uses the pattern `loaderPath!filePath`, hence the regex test
@@ -563,7 +561,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				{
 					test: /\.(css|js)$/,
 					issuer: indexHtmlPattern,
-					loader: `file-loader?digest=hex&name=[path][name].[ext]`
+					loader: 'file-loader?hash=sha512&digest=hex&name=[name].[hash:base64:8].[ext]'
 				},
 				esLint && {
 					include: allPaths,
@@ -642,7 +640,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				},
 				{
 					test: /\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2|ico)$/i,
-					loader: `file-loader?digest=hex&name=[path][name].[ext]`
+					loader: 'file-loader?hash=sha512&digest=hex&name=[name].[hash:base64:8].[ext]'
 				},
 				{
 					test: /\.m\.css\.js$/,

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -201,7 +201,6 @@ export class InsertScriptPlugin {
 export default function webpackConfigFactory(args: any): webpack.Configuration {
 	tsnode.register({ transpileOnly: true });
 	const isLegacy = args.legacy;
-	const base = args.target === 'electron' ? './' : args.base || '/';
 	const experimental = args.experimental || {};
 	const isExperimentalSpeed = !!experimental.speed && args.mode === 'dev';
 	const isTest = args.mode === 'unit' || args.mode === 'functional' || args.mode === 'test';

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -169,21 +169,6 @@ function webpackConfig(args: any): webpack.Configuration {
 		}
 		return plugin;
 	});
-	config.module = {
-		...config.module,
-		rules: ((config.module && config.module.rules) || []).map((rule) => {
-			if (rule && typeof rule.loader === 'string' && rule.loader.startsWith('file-loader')) {
-				return {
-					...rule,
-					loader: args.omitHash
-						? rule.loader
-						: `file-loader?hash=sha512&digest=hex&name=[path][name].[hash:base64:8].[ext]`
-				};
-			}
-
-			return rule;
-		})
-	};
 
 	if (Array.isArray(args.compression)) {
 		args.compression.forEach((algorithm: 'brotli' | 'gzip') => {


### PR DESCRIPTION
Reverts: #423 

This PR manually reverts https://github.com/dojo/cli-build-app/pull/423.
This code has been found to cause issues with image urls in css files where the final path from the html file requesting the image differs from the widget ts file that creates it. 

For example in a BTR environment with a webpage created at `src/pages/ClientA.tsx` requiring a css file from `src/pages/ClientA.m.css`.

```css
/* pages/ClientA.m.css */

.root {
   background-image: url('../images/clientABackground.jpg');
   /* full path is /src/images/clientABackground.jpg */
}
```

When the BTR site is build, in this case, the clientA page is now at `/clients/clientA.html` and the relative image path from the css file now resolves to `/src/pages/images/clientABackground.jpg` which is incorrect.

This approach will always cause us problems where the widget resulting in a webpage is not served in the same relative directory structure as the source files. This becomes further more problematic in circumstances where you may have a widget requiring css images served in multiple locations.

We must revisit #314 #315 when this has been reverted.
