### PR TITLE
Prepend main css file to the main bundle's css file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 yarn.lock
 /test-app/package-lock.json
 /test-app/.dojorc
+.vscode/

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -498,6 +498,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 			args.locale && new CldrPlugin(),
 			new webpack.DefinePlugin({
 				__MAIN_ENTRY: JSON.stringify(mainEntryPath),
+				__MAIN_CSS_PATH: JSON.stringify(existsSync(mainCssPath) ? mainCssPath : null),
 				__DOJO_SCOPE: `'${libraryName}'`
 			}),
 			!isExperimentalSpeed &&
@@ -515,6 +516,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 			!singleBundle &&
 				new BootstrapPlugin({
 					entryPath: mainEntryPath,
+					cssPath: existsSync(mainCssPath) ? mainCssPath : null,
 					shimModules: [
 						{
 							module: '@dojo/framework/shim/IntersectionObserver',

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -245,7 +245,6 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		staticOnly.push('build-elide');
 		entry = {
 			[bootstrapEntry]: removeEmpty([
-				existsSync(mainCssPath) ? mainCssPath : null,
 				'@dojo/framework/shim/Promise',
 				'@dojo/webpack-contrib/bootstrap-plugin/async'
 			])


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR
* [ ] schema.json has been updated appopriately

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
If main.css exists, pass path down to bootstrap plugin

Dependent on https://github.com/dojo/webpack-contrib/pull/335

Resolves #228 
